### PR TITLE
Some preliminary support of passing docker run options to services

### DIFF
--- a/api/src/infrastructure/docker.rs
+++ b/api/src/infrastructure/docker.rs
@@ -257,6 +257,7 @@ impl DockerInfrastructure {
 
         options.labels(&labels);
         options.restart_policy("always", 5);
+        options.volumes(service_config.docker_volumes());
 
         if let Some(memory_limit) = container_config.get_memory_limit() {
             options.memory(memory_limit.clone());

--- a/api/src/models/service.rs
+++ b/api/src/models/service.rs
@@ -33,6 +33,7 @@ use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 use url::Url;
+use core::borrow::Borrow;
 
 #[derive(Clone, Debug)]
 pub struct Service {
@@ -77,6 +78,8 @@ pub struct ServiceConfig {
     container_type: ContainerType,
     #[serde(skip)]
     port: u16,
+    #[serde(skip)]
+    docker_volumes: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
@@ -102,6 +105,7 @@ impl ServiceConfig {
             labels: None,
             container_type: ContainerType::Instance,
             port: 80,
+            docker_volumes: vec![],
         }
     }
 
@@ -158,6 +162,10 @@ impl ServiceConfig {
         }
     }
 
+    pub fn add_docker_volume(&mut self, volume: String) {
+        self.docker_volumes.push(volume)
+    }
+
     pub fn set_volumes(&mut self, volumes: Option<BTreeMap<String, String>>) {
         self.volumes = volumes;
     }
@@ -167,6 +175,10 @@ impl ServiceConfig {
             None => None,
             Some(volumes) => Some(&volumes),
         }
+    }
+
+    pub fn docker_volumes(&self) -> Vec<&str> {
+        self.docker_volumes.iter().map(|s| s.borrow()).collect()
     }
 
     pub fn set_port(&mut self, port: u16) {

--- a/api/src/services/apps_service.rs
+++ b/api/src/services/apps_service.rs
@@ -234,6 +234,7 @@ impl AppsService {
             }
 
             self.config.add_secrets_to(config, app_name);
+            self.config.add_options_to(config, app_name);
         }
 
         let mut service_companions = Vec::new();


### PR DESCRIPTION
In my usecase I need to pass parameters (specifically volumes) to `docker run`. This change adds a service option "volumes" to be set in the PREvant configuration. It could be extended to other `docker run` parameters. This PR is meant as a base for discussion of how to add this kind of feature to PREvant.