### PR TITLE
Sleep between host meta crawls

### DIFF
--- a/api/src/apps/host_meta_cache.rs
+++ b/api/src/apps/host_meta_cache.rs
@@ -12,7 +12,7 @@ use std::convert::From;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::interval;
+use tokio::time::sleep;
 use yansi::Paint;
 
 pub struct HostMetaCache {
@@ -85,9 +85,8 @@ impl HostMetaCrawler {
         let timestamp_prevant_startup = Utc::now();
 
         runtime.handle().spawn(async move {
-            let mut interval = interval(Duration::from_secs(5));
             loop {
-                interval.tick().await;
+                sleep(Duration::from_secs(5)).await;
                 if let Err(err) = self.crawl(&apps, timestamp_prevant_startup).await {
                     error!("Cannot load apps: {}", err);
                 }


### PR DESCRIPTION
This reverts to the previous behavior of sleeping *5 secs between* each iteration of crawling host-meta info.

My PR #55 inadvertently switched to sleeping *at most 5 secs*, or not sleeping at all, in case crawling took longer than 5 seconds, leading to increased CPU and memory consumption.

(See: https://docs.rs/tokio/1.5.0/tokio/time/fn.interval.html#examples)