### PR TITLE
Fix missing space at duplication dialog

### DIFF
--- a/frontend/src/DuplicateAppDialog.vue
+++ b/frontend/src/DuplicateAppDialog.vue
@@ -25,7 +25,7 @@
  */
 
 <template>
-   <dlg ref="dialog" :title="'Duplicate' + duplicateFromAppName" :error-status="errorStatus" :error-status-text="errorStatusText">
+   <dlg ref="dialog" :title="'Duplicate ' + duplicateFromAppName" :error-status="errorStatus" :error-status-text="errorStatusText">
       <template slot="body">
          <div class="form-group">
             <input


### PR DESCRIPTION
I noticed that a space is missing from the duplication dialog.

<img width="513" alt="grafik" src="https://user-images.githubusercontent.com/36853386/126634247-c49e6b20-bced-4a75-9c0a-060a2dc6d194.png">
