### PR TITLE
Renaming 'volumes' to 'files' and adding SecStr support

### DIFF
--- a/api/res/openapi.yml
+++ b/api/res/openapi.yml
@@ -376,10 +376,27 @@ components:
           $ref: '#/components/schemas/EnvironmentConfiguration'
         volumes:
           type: object
+          deprecated: true
           description: >-
             Files to be created in the the container.
             <p>
             The keys of this object are the paths in the container and the values contain the actual file content.
+            <p>
+            This field has been deprecated in favor of `files`. Kindly use `files` for future usage.
+          example:
+            "/etc/mysql/my.cnf": |
+              [client-server]
+              # Uncomment these if you want to use a nonstandard connection to MariaDB
+              #socket=/tmp/mysql.sock
+              #port=3306
+        files:
+          type: object
+          description: >-
+            Files to be created in the the container.
+            <p>
+            The keys of this object are the paths in the container and the values contain the actual file content.
+            <p>
+            This field replaces the deprecated `volumes`.
           example:
             "/etc/mysql/my.cnf": |
               [client-server]

--- a/api/src/apps/deployment_unit.rs
+++ b/api/src/apps/deployment_unit.rs
@@ -367,7 +367,7 @@ mod tests {
                 "openid",
                 labels = (),
                 env = ("VAR_1" => "efg"),
-                volumes = ()
+                files = ()
             )],
         );
 
@@ -415,7 +415,7 @@ mod tests {
                 "openid",
                 labels = (),
                 env = ("VAR_1" => "efg"),
-                volumes = ()
+                files = ()
             )],
         );
 

--- a/api/src/config/companion.rs
+++ b/api/src/config/companion.rs
@@ -26,6 +26,7 @@
 use crate::config::AppSelector;
 use crate::models::service::ContainerType;
 use crate::models::{Environment, Image, Router, ServiceConfig};
+use secstr::SecUtf8;
 use serde_value::Value;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -41,7 +42,8 @@ pub(super) struct Companion {
     deployment_strategy: DeploymentStrategy,
     env: Option<Environment>,
     labels: Option<BTreeMap<String, String>>,
-    volumes: Option<BTreeMap<PathBuf, String>>,
+    #[serde(alias = "volumes", alias = "files", default)]
+    files: Option<BTreeMap<PathBuf, SecUtf8>>,
     #[serde(default = "AppSelector::default")]
     app_selector: AppSelector,
     router: Option<Router>,
@@ -94,8 +96,8 @@ impl From<Companion> for ServiceConfig {
         }));
         config.set_labels(companion.labels.clone());
 
-        if let Some(volumes) = &companion.volumes {
-            config.set_volumes(Some(volumes.clone()));
+        if let Some(files) = &companion.files {
+            config.set_files(Some(files.clone()));
         }
 
         if let Some(router) = &companion.router {

--- a/api/src/infrastructure/kubernetes/infrastructure.rs
+++ b/api/src/infrastructure/kubernetes/infrastructure.rs
@@ -341,8 +341,8 @@ impl KubernetesInfrastructure {
         strategy: &'a DeploymentStrategy,
         container_config: &ContainerConfig,
     ) -> Result<&'a DeploymentStrategy, KubernetesInfrastructureError> {
-        if let Some(volumes) = strategy.volumes() {
-            self.deploy_secret(app_name, strategy, volumes).await?;
+        if let Some(files) = strategy.files() {
+            self.deploy_secret(app_name, strategy, &files).await?;
         }
 
         let client = self.client().await?;
@@ -404,7 +404,7 @@ impl KubernetesInfrastructure {
         &self,
         app_name: &String,
         service_config: &ServiceConfig,
-        volumes: &BTreeMap<PathBuf, String>,
+        volumes: &BTreeMap<PathBuf, SecUtf8>,
     ) -> Result<(), KubernetesInfrastructureError> {
         debug!(
             "Deploying volumes as secrets for {} in app {}",
@@ -795,8 +795,6 @@ mod tests {
     use crate::models::EnvironmentVariable;
     use k8s_openapi::api::apps::v1::DeploymentSpec;
     use kube::api::ObjectMeta;
-    use secstr::SecUtf8;
-    use std::collections::BTreeMap;
 
     macro_rules! deployment_object {
         ($deployment_name:expr, $app_name:expr, $service_name:expr, $image:expr, $container_type:expr, $($a_key:expr => $a_value:expr),*) => {{


### PR DESCRIPTION
Rename of field 'volumes' to 'files' in service_config & companions. Being done in relation to [issue#8](https://github.com/aixigo/PREvant/issues/8)
- Service config and Companion has the ability to use both volumes and files in the JSON
- 'volumes' field to be deprecated, relevant messages added to openApi.yaml
- Change affects 11 files in total : Backward compatibility tests in place for serialization and deserialization of the new field files and old field volumes. No test cases written for internally called functions.
- File data is now stored as a SecStr to avoid data leakage within the program.