### PR TITLE
Adding Docker Volume Functionality

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -176,6 +176,22 @@ deploymentStrategy = 'redeploy-on-image-update'
 - `redeploy-on-image-update`: Re-deploys the companion if there is a more rescent image available.
 - `redeploy-never`: Even if there is a new deployment request the companion won't be redeployed and stays running.
 
+### Storage Strategy
+
+Companions may have varying storage requirements and storage strategies cater to these by offering the below configuration flags:
+
+```toml
+[companions.postgres]
+type = 'application'
+image = 'postgres:latest'
+storageStrategy = 'mount-declared-image-volumes'
+```
+
+`storageStrategy` offers following values to determine how storage is managed for a companion:
+
+- `none` (_default_): Companion is deployed without persistent storage.
+- `mount-declared-image-volumes`: Mounts the volume paths declared within the image, providing persistent storage for the companion.
+
 ## Hooks
 
 Hooks can be used to manipulate the deployment before handing it over to actual infrastructure and they are able to manipulate all service configurations once for any deployment REST API call. For example, based on the deployment's app name you can decide to reconfigure your services to use a different DBMS so that you are able to verify that your services work with different DBMSs.

--- a/api/src/config/companion.rs
+++ b/api/src/config/companion.rs
@@ -48,6 +48,8 @@ pub(super) struct Companion {
     app_selector: AppSelector,
     router: Option<Router>,
     middlewares: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
+    storage_strategy: StorageStrategy,
 }
 
 #[derive(Clone, Deserialize, Debug, PartialEq)]
@@ -56,6 +58,14 @@ pub(super) enum CompanionType {
     Application,
     #[serde(rename = "service")]
     Service,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub enum StorageStrategy {
+    #[serde(rename = "none")]
+    NoMountVolumes,
+    #[serde(rename = "mount-declared-image-volumes")]
+    MountDeclaredImageVolumes,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -79,6 +89,10 @@ impl Companion {
 
     pub fn deployment_strategy(&self) -> &DeploymentStrategy {
         &self.deployment_strategy
+    }
+
+    pub fn storage_strategy(&self) -> &StorageStrategy {
+        &self.storage_strategy
     }
 }
 
@@ -126,6 +140,12 @@ impl From<CompanionType> for ContainerType {
 impl Default for DeploymentStrategy {
     fn default() -> Self {
         Self::RedeployAlways
+    }
+}
+
+impl Default for StorageStrategy {
+    fn default() -> Self {
+        Self::NoMountVolumes
     }
 }
 

--- a/api/src/infrastructure/docker.rs
+++ b/api/src/infrastructure/docker.rs
@@ -43,15 +43,15 @@ use regex::Regex;
 use shiplift::container::{ContainerCreateInfo, ContainerDetails, ContainerInfo};
 use shiplift::errors::Error as ShipLiftError;
 use shiplift::tty::TtyChunk;
+use shiplift::volume::VolumeInfo;
 use shiplift::{
     ContainerConnectionOptions, ContainerFilter, ContainerListOptions, ContainerOptions, Docker,
-    LogsOptions, NetworkCreateOptions, PullOptions, RegistryAuth,
+    LogsOptions, NetworkCreateOptions, PullOptions, RegistryAuth, VolumeCreateOptions,
 };
 use std::collections::HashMap;
 use std::convert::{From, TryFrom};
 use std::net::{AddrParseError, IpAddr};
 use std::str::FromStr;
-
 static CONTAINER_PORT_LABEL: &str = "traefik.port";
 
 pub struct DockerInfrastructure {
@@ -241,19 +241,37 @@ impl DockerInfrastructure {
         Ok(())
     }
 
+    async fn delete_volume_mount(&self, app_name: &String) -> Result<(), ShipLiftError> {
+        let docker = Docker::new();
+        let docker_volumes = docker.volumes();
+        for volume in DockerInfrastructure::fetch_existing_volumes(app_name).await? {
+            docker_volumes.get(&volume.name).delete().await?
+        }
+        Ok(())
+    }
+
     async fn deploy_services_impl(
         &self,
-        app_name: &String,
-        services: &[DeployableService],
+        deployment_unit: &DeploymentUnit,
         container_config: &ContainerConfig,
     ) -> Result<Vec<Service>, Error> {
+        let app_name = deployment_unit.app_name();
+        let services = deployment_unit.services();
         let network_id = self.create_or_get_network_id(app_name).await?;
 
         self.connect_traefik(&network_id).await?;
-
+        let existing_volumes = DockerInfrastructure::fetch_existing_volumes(app_name).await?;
         let futures = services
             .iter()
-            .map(|service| self.start_container(app_name, &network_id, service, container_config))
+            .map(|service| {
+                self.start_container(
+                    app_name,
+                    &network_id,
+                    service,
+                    container_config,
+                    &existing_volumes,
+                )
+            })
             .collect::<Vec<_>>();
 
         let mut services: Vec<Service> = Vec::new();
@@ -294,6 +312,7 @@ impl DockerInfrastructure {
         }
 
         self.delete_network(app_name).await?;
+        self.delete_volume_mount(app_name).await?;
 
         Ok(services)
     }
@@ -304,6 +323,7 @@ impl DockerInfrastructure {
         network_id: &String,
         service: &DeployableService,
         container_config: &ContainerConfig,
+        existing_volumes: &[VolumeInfo],
     ) -> Result<Service, Error> {
         let docker = Docker::new();
         let containers = docker.containers();
@@ -312,7 +332,6 @@ impl DockerInfrastructure {
         if let Image::Named { .. } = service.image() {
             self.pull_image(app_name, service).await?;
         }
-
         let mut image_to_delete = None;
         if let Some(ref container_info) = self
             .get_app_container(app_name, service.service_name())
@@ -350,7 +369,6 @@ impl DockerInfrastructure {
                     .await?;
             }
             container.delete().await?;
-
             image_to_delete = Some(container_details.image);
         }
 
@@ -362,8 +380,16 @@ impl DockerInfrastructure {
             service.container_type(),
         );
 
-        let options =
-            DockerInfrastructure::create_container_options(app_name, service, container_config);
+        let host_config_binds =
+            DockerInfrastructure::create_host_config_binds(app_name, existing_volumes, service)
+                .await?;
+
+        let options = DockerInfrastructure::create_container_options(
+            app_name,
+            service,
+            container_config,
+            &host_config_binds,
+        );
 
         let container_info = containers.create(&options).await?;
         debug!("Created container: {:?}", container_info);
@@ -400,14 +426,14 @@ impl DockerInfrastructure {
                 Err(err) => debug!("Could not clean up image: {:?}", err),
             }
         }
-
         Ok(Service::try_from(&container_details)?)
     }
 
     fn create_container_options(
-        app_name: &String,
+        app_name: &str,
         service_config: &ServiceConfig,
         container_config: &ContainerConfig,
+        host_config_binds: &[String],
     ) -> ContainerOptions {
         let mut options = ContainerOptions::builder(&service_config.image().to_string());
         if let Some(env) = service_config.env() {
@@ -451,6 +477,9 @@ impl DockerInfrastructure {
             labels.insert(REPLICATED_ENV_LABEL, replicated_env);
         }
 
+        if !host_config_binds.is_empty() {
+            options.volumes(host_config_binds.iter().map(|bind| bind.as_str()).collect());
+        }
         options.labels(&labels);
         options.restart_policy("always", 5);
 
@@ -489,6 +518,72 @@ impl DockerInfrastructure {
         }
 
         Ok(())
+    }
+
+    async fn fetch_existing_volumes(app_name: &String) -> Result<Vec<VolumeInfo>, ShipLiftError> {
+        let docker = Docker::new();
+        docker.volumes().list().await.map(|volume_infos| {
+            volume_infos
+                .into_iter()
+                .filter(|s| {
+                    s.labels
+                        .as_ref()
+                        .map(|label| label.get(APP_NAME_LABEL) == Some(app_name))
+                        .unwrap_or(false)
+                })
+                .collect::<Vec<VolumeInfo>>()
+        })
+    }
+
+    async fn create_docker_volume(
+        app_name: &str,
+        service: &DeployableService,
+    ) -> Result<String, ShipLiftError> {
+        let docker = Docker::new();
+        let volumes = docker.volumes();
+
+        let mut labels: HashMap<&str, &str> = HashMap::new();
+        labels.insert(APP_NAME_LABEL, app_name);
+        labels.insert(SERVICE_NAME_LABEL, service.service_name());
+
+        let volume_options = VolumeCreateOptions::builder().labels(&labels).build();
+        volumes
+            .create(&volume_options)
+            .await
+            .map(|volume_info| volume_info.name)
+    }
+
+    async fn create_host_config_binds(
+        app_name: &str,
+        existing_volume: &[VolumeInfo],
+        service: &DeployableService,
+    ) -> Result<Vec<String>, ShipLiftError> {
+        let mut host_binds = Vec::new();
+
+        if service.declared_volumes().is_empty() {
+            return Ok(host_binds);
+        }
+
+        let service_volume = existing_volume
+            .iter()
+            .find(|vol| {
+                vol.labels.as_ref().map_or_else(
+                    || false,
+                    |label| label.get(SERVICE_NAME_LABEL) == Some(service.service_name()),
+                )
+            })
+            .map(|info| &info.name);
+
+        let volume_name = match service_volume {
+            Some(name) => String::from(name),
+            None => DockerInfrastructure::create_docker_volume(app_name, service).await?,
+        };
+
+        for declared_volume in service.declared_volumes() {
+            host_binds.push(format!("{}:{}", volume_name, declared_volume));
+        }
+
+        Ok(host_binds)
     }
 
     async fn pull_image(
@@ -620,13 +715,12 @@ impl Infrastructure for DockerInfrastructure {
         deployment_unit: &DeploymentUnit,
         container_config: &ContainerConfig,
     ) -> Result<Vec<Service>, Error> {
-        let app_name = deployment_unit.app_name();
         let deployment_container = self
-            .create_status_change_container(status_id, app_name)
+            .create_status_change_container(status_id, deployment_unit.app_name())
             .await?;
 
         let result = self
-            .deploy_services_impl(app_name, deployment_unit.services(), container_config)
+            .deploy_services_impl(deployment_unit, container_config)
             .await;
 
         delete(deployment_container).await?;
@@ -1159,6 +1253,7 @@ mod tests {
             &String::from("master"),
             &config,
             &ContainerConfig::default(),
+            &Vec::new(),
         );
 
         let json = serde_json::to_value(&options).unwrap();
@@ -1193,6 +1288,7 @@ mod tests {
             &String::from("master"),
             &config,
             &ContainerConfig::default(),
+            &Vec::new(),
         );
 
         let json = serde_json::to_value(&options).unwrap();
@@ -1232,6 +1328,7 @@ mod tests {
             &String::from("master"),
             &config,
             &ContainerConfig::default(),
+            &Vec::new(),
         );
 
         let json = serde_json::to_value(&options).unwrap();
@@ -1345,6 +1442,38 @@ mod tests {
                 String::from("MYSQL_ROOT_PASSWORD"),
                 SecUtf8::from("example")
             )
+        );
+    }
+
+    #[test]
+    fn should_create_container_options_with_host_config_binds() {
+        let config = sc!("db", "mariadb:10.3.17");
+
+        let options = DockerInfrastructure::create_container_options(
+            &String::from("master"),
+            &config,
+            &ContainerConfig::default(),
+            &[String::from("test-volume:/var/lib/mysql")],
+        );
+
+        let json = serde_json::to_value(&options).unwrap();
+        assert_json_diff::assert_json_eq!(
+            json,
+            serde_json::json!({
+              "name": null,
+              "params": {
+                "HostConfig.RestartPolicy.Name": "always",
+                "Image": "docker.io/library/mariadb:10.3.17",
+                "HostConfig.Binds":["test-volume:/var/lib/mysql"],
+                "Labels": {
+                  "com.aixigo.preview.servant.app-name": "master",
+                  "com.aixigo.preview.servant.container-type": "instance",
+                  "com.aixigo.preview.servant.service-name": "db",
+                  "com.aixigo.preview.servant.image": "docker.io/library/mariadb:10.3.17",
+                  "traefik.frontend.rule": "PathPrefixStrip: /master/db/; PathPrefix:/master/db/;"
+                }
+              }
+            })
         );
     }
 }

--- a/api/src/infrastructure/kubernetes/payloads.rs
+++ b/api/src/infrastructure/kubernetes/payloads.rs
@@ -600,6 +600,7 @@ mod tests {
                 TraefikIngressRoute::with_rule(TraefikRouterRule::path_prefix_rule(&[
                     "master", "db",
                 ])),
+                Vec::new(),
             ),
             &ContainerConfig::default(),
             false,
@@ -677,6 +678,7 @@ mod tests {
                 TraefikIngressRoute::with_rule(TraefikRouterRule::path_prefix_rule(&[
                     "master", "db",
                 ])),
+                Vec::new(),
             ),
             &ContainerConfig::default(),
             false,
@@ -757,6 +759,7 @@ mod tests {
                 TraefikIngressRoute::with_rule(TraefikRouterRule::path_prefix_rule(&[
                     "master", "db",
                 ])),
+                Vec::new(),
             ),
             &ContainerConfig::default(),
             false,
@@ -836,6 +839,7 @@ mod tests {
             config,
             DeploymentStrategy::RedeployAlways,
             TraefikIngressRoute::with_defaults(&AppName::from_str("master").unwrap(), "db"),
+            Vec::new(),
         );
         let payload = ingress_route_payload(&app_name, &config);
 
@@ -878,6 +882,7 @@ mod tests {
             config,
             DeploymentStrategy::RedeployAlways,
             TraefikIngressRoute::with_defaults(&AppName::from_str("master").unwrap(), "db"),
+            Vec::new(),
         );
 
         let payload = middleware_payload(&String::from("master"), &service);


### PR DESCRIPTION
In a nutshell below is the logic used for implementation
-In infrastructure.rs a list of all available volumes for the app_name is collected
- Once the individual ServiceConfig is accessible, the ImageInfo is extracted from the DeploymentUnit and passed to start_container.
- A combination of app_name, image_info, existing_volume and the service config is passed to a new function to create the host config bind.
- The logic to create host config bind is :
-     If the existing volume does not contain any volume matching the service_name in label then a new volume is
       created in the docker environment,
-     If there is any existing volume then we use `find` functionality to fetch the first occurrence in the list of 
       existing volume. The reason for this being that there should exist only 1 combination of the app_name
       and service_name as labels, No duplicates are allowed.
-     The volume name from any of the above match is merged with attached_volumes(which is the Volumes present 
       in the docker image manifest) in the format "{}:{}"
- The host_config_bind is then passed to the create_container_options function which will ensure the options will result in volume mount creation once container is started.
- A new Container option is added to Enable/Disable feature in config.toml
`[containers]
docker_volume_enabled = false`