### PR TITLE
Merge PREvant's Traefik Route with Services Routes

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-        
-      - name: Install latest nightly
+
+      - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             override: true
 
       - name: Run cargo test
@@ -30,10 +30,10 @@ jobs:
       - name: Build Docker Image
         run: docker build --pull -t aixigo/prevant .
 
-      - name: Install latest nightly
+      - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - name: Run cargo test

--- a/Develop.md
+++ b/Develop.md
@@ -4,6 +4,8 @@ This file provides some hints and examples how to develop PREvant.
 
 You can build PREvant's backend API with [`cargo`](https://doc.rust-lang.org/cargo/) in the sub directory `/api`. For example, `cargo run` build and starts the backend so that it will be available at `http://localhost:8000`. 
 
+When you than interact with the REST API to deploy service, it is worthwhile to have a look into the [Traefik dashboard](https://doc.traefik.io/traefik/operations/dashboard/#the-dashboard) to double check if PREvant exposes the services as expected.
+
 If you want to use PREvant's frontend during development, head over to the [Frontend Development section](#fe-dev).
 
 Without any CLI options, PREvant will use the Docker API. If you want to develop with against Kubernetes, have a look into the [Kubernetes section](#k8s-dev).
@@ -27,9 +29,17 @@ For developing against a local Kubernetes cluster you can use [k3d](https://k3d.
 3. Deploy some containers and observe the result [here](http://localhost/master/whoami/):
 
    ```bash
-   curl -X POST -d '[{"serviceName": "whoami", "image": "quay.io/truecharts/whoami"}]' \
+   # PREvant can't handle multi arch images, yet (see https://github.com/aixigo/PREvant/issues/125)
+   # Therefore, the example uses 1.8.1 which hasn't multi arch versions
+   curl -X POST -d '[{"serviceName": "whoami", "image": "quay.io/truecharts/whoami:1.8.1"}]' \
       -H "Content-type: application/json" \
       http://localhost:8000/api/apps/master
+   ```
+
+4. Check Traefik's dashboard by exposing the port (see command below and detail [here](https://stackoverflow.com/q/68565048/5088458)) and visit [`http://localhost:9000/dashboard`](http://localhost:9000/dashboard).
+
+   ```bash
+   kubectl -n kube-system port-forward $(kubectl -n kube-system get pods --selector "app.kubernetes.io/name=traefik" --output name) 9000:9000
    ```
 
 # <a name="fe-dev"></a>Frontend Development

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,15 @@ RUN npm ci && npm run build
 # Build Backend
 FROM rust:1 as backend-builder
 COPY api/Cargo.toml api/Cargo.lock /usr/src/api/
-COPY api/src /usr/src/api/src
 WORKDIR /usr/src/api
+
+# Improves build caching, see https://stackoverflow.com/a/58474618/5088458
+RUN sed -i 's#src/main.rs#src/dummy.rs#' Cargo.toml
+RUN mkdir src && echo "fn main() {}" > src/dummy.rs
+RUN cargo build --release
+
+RUN sed -i 's#src/dummy.rs#src/main.rs#' Cargo.toml && rm src/dummy.rs
+COPY api/src /usr/src/api/src
 RUN cargo build --release
 
 

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -70,7 +70,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -81,17 +81,14 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "atomic"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
-dependencies = [
- "autocfg",
-]
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atty"
@@ -120,7 +117,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -133,9 +130,15 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1e31e207a6b8fb791a38ea3105e6cb541f55e4d029902d3039a4ad07cc4105"
 
 [[package]]
 name = "binascii"
@@ -151,9 +154,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d1372b52fa64b8af7cf6e3848cfa2dadb81c21e810f144bdd9c26e21895235"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "block-buffer"
@@ -240,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -298,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
@@ -315,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -336,23 +339,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "cookie"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "percent-encoding",
- "time 0.3.20",
+ "time 0.3.21",
  "version_check",
 ]
 
@@ -374,9 +367,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -398,50 +391,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]
@@ -505,11 +454,11 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
 dependencies = [
- "bitflags 2.2.0",
+ "bitflags 2.3.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -523,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
@@ -555,7 +504,7 @@ dependencies = [
 [[package]]
 name = "dkregistry"
 version = "0.5.1-alpha.0"
-source = "git+https://github.com/camallo/dkregistry-rs.git?rev=37acecb4b8139dd1b1cc83795442f94f90e1ffc5#37acecb4b8139dd1b1cc83795442f94f90e1ffc5"
+source = "git+https://github.com/camallo/dkregistry-rs.git?rev=0642b1c#0642b1ccf85d82090e4a397bbe99b20108ab0f7f"
 dependencies = [
  "async-stream",
  "base64 0.13.1",
@@ -565,9 +514,9 @@ dependencies = [
  "libflate",
  "log",
  "mime",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "regex",
- "reqwest 0.11.16",
+ "reqwest 0.11.18",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -576,7 +525,7 @@ dependencies = [
  "strum_macros",
  "tar",
  "thiserror",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "url",
 ]
 
@@ -713,12 +662,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -829,7 +778,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -898,15 +847,15 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a20a288a94683f5f4da0adecdbe095c94a77c295e514cc6484e9394dd8376e"
+checksum = "f3e123d9ae7c02966b4d892e550bdc32164f05853cd40ab570650ad600596a8a"
 dependencies = [
  "cc",
  "libc",
  "log",
  "rustversion",
- "windows 0.44.0",
+ "windows",
 ]
 
 [[package]]
@@ -977,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -989,8 +938,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.27.0",
- "tokio-util 0.7.7",
+ "tokio 1.28.1",
+ "tokio-util 0.7.8",
  "tracing",
 ]
 
@@ -1165,7 +1114,7 @@ dependencies = [
  "httparse",
  "httpdate 0.3.2",
  "itoa 0.4.8",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "socket2 0.3.19",
  "tokio 0.2.25",
  "tower-service",
@@ -1183,7 +1132,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.18",
+ "h2 0.3.19",
  "http",
  "http-body 0.4.5",
  "httparse",
@@ -1191,7 +1140,7 @@ dependencies = [
  "itoa 1.0.6",
  "pin-project-lite 0.2.9",
  "socket2 0.4.9",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tower-service",
  "tracing",
  "want",
@@ -1210,7 +1159,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "parking_lot",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tokio-openssl",
  "tower-layer",
 ]
@@ -1223,7 +1172,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper 0.14.26",
  "pin-project-lite 0.2.9",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tokio-io-timeout",
 ]
 
@@ -1249,7 +1198,7 @@ dependencies = [
  "bytes 1.4.0",
  "hyper 0.14.26",
  "native-tls",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tokio-native-tls",
 ]
 
@@ -1262,8 +1211,8 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper 0.14.26",
- "pin-project 1.0.12",
- "tokio 1.27.0",
+ "pin-project 1.1.0",
+ "tokio 1.28.1",
 ]
 
 [[package]]
@@ -1277,17 +1226,16 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.48.0",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1384,9 +1332,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1404,11 +1352,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.1",
  "bytes 1.4.0",
  "chrono",
  "serde",
@@ -1428,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.74.0"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
+checksum = "dc7d3d52dd5c871991679102e80dfb192faaaa09fecdbccdd8c55af264ce7a8f"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1440,11 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
+checksum = "544339f1665488243f79080441cacb09c997746fd763342303e66eebb9d3ba13"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes 1.4.0",
  "chrono",
  "dirs-next",
@@ -1460,14 +1408,14 @@ dependencies = [
  "kube-core",
  "openssl",
  "pem",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml 0.9.21",
  "thiserror",
- "tokio 1.27.0",
- "tokio-util 0.7.7",
+ "tokio 1.28.1",
+ "tokio-util 0.7.8",
  "tower",
  "tower-http",
  "tracing",
@@ -1475,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
+checksum = "25983d07f414dfffba08c5951fe110f649113416b1d8e22f7c89c750eb2555a7"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -1492,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.74.0"
+version = "0.82.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d74121eb41af4480052901f31142d8d9bbdf1b7c6b856da43bcb02f5b1b177"
+checksum = "5af652b642aca19ef5194de3506aa39f89d788d5326a570da68b13a02d6c5ba2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1511,15 +1459,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libflate"
-version = "1.3.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97822bf791bd4d5b403713886a5fbe8bf49520fe78e323b0dc480ca1a03e50b0"
+checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
 dependencies = [
  "adler32",
  "crc32fast",
@@ -1533,15 +1481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
  "rle-decode-fast",
-]
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1561,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1640,6 +1579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,8 +1645,8 @@ dependencies = [
  "memchr",
  "mime",
  "spin",
- "tokio 1.27.0",
- "tokio-util 0.7.7",
+ "tokio 1.28.1",
+ "tokio-util 0.7.8",
  "version_check",
 ]
 
@@ -1814,9 +1762,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -1835,7 +1783,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1846,9 +1794,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -1926,7 +1874,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1946,9 +1894,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1956,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1966,22 +1914,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -2041,11 +1989,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
- "pin-project-internal 1.0.12",
+ "pin-project-internal 1.1.0",
 ]
 
 [[package]]
@@ -2061,13 +2009,13 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2090,9 +2038,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -2125,8 +2073,10 @@ dependencies = [
  "log",
  "multimap",
  "openssl",
+ "pest",
+ "pest_derive",
  "regex",
- "reqwest 0.11.16",
+ "reqwest 0.11.18",
  "rocket",
  "schemars",
  "secstr",
@@ -2135,11 +2085,11 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_regex",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "shiplift",
  "tempfile",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "toml",
  "url",
  "uuid",
@@ -2172,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2187,7 +2137,7 @@ checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
  "version_check",
  "yansi",
 ]
@@ -2200,9 +2150,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -2283,18 +2233,18 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -2303,7 +2253,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2311,6 +2261,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "regress"
@@ -2358,16 +2314,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.1",
  "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.18",
+ "h2 0.3.19",
  "http",
  "http-body 0.4.5",
  "hyper 0.14.26",
@@ -2383,9 +2339,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tokio-native-tls",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2431,10 +2387,10 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.3.20",
- "tokio 1.27.0",
+ "time 0.3.21",
+ "tokio 1.28.1",
  "tokio-stream",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.8",
  "ubyte",
  "version_check",
  "yansi",
@@ -2452,7 +2408,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.15",
+ "syn 2.0.16",
  "unicode-xid",
 ]
 
@@ -2478,8 +2434,8 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.3.20",
- "tokio 1.27.0",
+ "time 0.3.21",
+ "tokio 1.28.1",
  "uncased",
 ]
 
@@ -2497,9 +2453,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2582,12 +2538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,9 +2559,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -2622,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2632,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -2651,13 +2601,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2727,6 +2677,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa 1.0.6",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,7 +2710,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2776,11 +2739,11 @@ dependencies = [
  "log",
  "mime",
  "paste",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "serde",
  "serde_json",
  "tar",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "url",
 ]
 
@@ -2903,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2986,7 +2949,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3012,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa 1.0.6",
  "serde",
@@ -3024,15 +2987,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -3072,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
@@ -3085,7 +3048,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3095,18 +3058,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.9",
- "tokio 1.27.0",
+ "tokio 1.28.1",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3116,7 +3079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio 1.27.0",
+ "tokio 1.28.1",
 ]
 
 [[package]]
@@ -3128,18 +3091,18 @@ dependencies = [
  "futures-util",
  "openssl",
  "openssl-sys",
- "tokio 1.27.0",
+ "tokio 1.28.1",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
- "tokio 1.27.0",
+ "tokio 1.28.1",
 ]
 
 [[package]]
@@ -3168,15 +3131,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.9",
- "tokio 1.27.0",
+ "tokio 1.28.1",
  "tracing",
 ]
 
@@ -3197,10 +3160,10 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "pin-project-lite 0.2.9",
- "tokio 1.27.0",
- "tokio-util 0.7.7",
+ "tokio 1.28.1",
+ "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3208,11 +3171,11 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bitflags 1.3.2",
  "bytes 1.4.0",
  "futures-core",
@@ -3220,6 +3183,7 @@ dependencies = [
  "http",
  "http-body 0.4.5",
  "http-range-header",
+ "mime",
  "pin-project-lite 0.2.9",
  "tower-layer",
  "tower-service",
@@ -3253,20 +3217,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3278,7 +3242,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "tracing",
 ]
 
@@ -3295,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3340,9 +3304,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "uncased"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
 dependencies = [
  "serde",
  "version_check",
@@ -3391,16 +3355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
@@ -3416,9 +3380,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
  "serde",
@@ -3476,9 +3440,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3488,24 +3452,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3515,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3525,22 +3489,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-streams"
@@ -3557,9 +3521,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3607,15 +3571,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
-dependencies = [
- "windows-targets 0.42.2",
-]
 
 [[package]]
 name = "windows"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 
 resolver = "2"
 
+[[bin]]
+name = "prevant"
+path = "src/main.rs"
+
 [dependencies]
 async-trait = "0.1"
 base64 = "0.13"
@@ -20,12 +24,14 @@ figment = { version = "0.10", features = ["env", "toml"] }
 futures = { version = "0.3", features = ["compat"] }
 handlebars = "2"
 http-api-problem = "0.56"
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_24"] }
-kube = { version = "0.74", features = ["derive"] }
+k8s-openapi = { version = "0.18", default-features = false, features = ["v1_24"] }
+kube = { version = "0.82", features = ["derive"] }
 lazy_static = "1.4"
 log = "0.4"
 multimap = "0.8"
 openssl = "0.10"
+pest = "2.3"
+pest_derive = "2.3"
 regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 rocket = { version = "0.5.0-rc.3", features = ["json"] }
@@ -49,7 +55,7 @@ rev = "5916526332951a144b6f6fd7c94d02ea56fdad31"
 
 [dependencies.dkregistry]
 git = "https://github.com/camallo/dkregistry-rs.git"
-rev = "37acecb4b8139dd1b1cc83795442f94f90e1ffc5"
+rev = "0642b1c"
 
 [dependencies.shiplift]
 git = "https://github.com/softprops/shiplift.git"

--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,22 @@ The image `aixigo/prevant` provides the REST-API in order to deploy containers a
 
 # Configuration
 
-In order to configure PREvant create a [TOML](https://github.com/toml-lang/toml) file that is mounted to the container's path `/app/config.toml`.
+In order to configure PREvant create a [TOML](https://github.com/toml-lang/toml) file that is mounted to the container's path `/app/config.toml` (path can be changed by the CLI option `--config`). Additionally, PREvant utilizes [figment][1] to read configuration options from file, environment variable, and from some CLI options.
+
+## Runtime Configuration
+
+### Kubernetes
+
+```toml
+[runtime]
+type = 'Kubernetes'
+
+[runtime.downwardApi]
+# Path to the file that contains the labels that have been assigned to the PREvant deployemnt itself.
+# This information is crucial if you run PREvant behind a Traefik instance that enforces the user ot be
+# logged in.
+labelsPath = '/run/podinfo/labels'
+```
 
 ## Container Options
 
@@ -49,7 +64,7 @@ data = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS…FUlRJRklDQVRFLS0tLS0K"
 # mounted for this service. Default is ".+" (any app)
 appSelector = "master"
 # An optional path that points to the secret's parent directory.
-# Default is "/run/secrets" 
+# Default is "/run/secrets"
 path = "/run/secrets"
 
 [[services.nginx.secrets]]
@@ -180,7 +195,7 @@ function deploymentHook(appName, serviceConfigs) {
 }
 ```
 
-Note: the templating has been already applied and the hook has only access to the final value and it cannot modify the original values. 
+Note: the templating has been already applied and the hook has only access to the final value and it cannot modify the original values.
 
 Note: the hook's Javascript engine is based on [Boa](https://github.com/boa-dev/boa) and this engine does not implement all ECMAScript features yet.
 
@@ -208,3 +223,16 @@ username = "oauth2"
 password = "your-private-token"
 ```
 
+## Configure With Environment Variables
+
+As stated above, PREvant utilizes [figment][1] to resolve configuration values from file, environment variables, and CLI options. The following examples provide a reference how to use environment variables to configure PREvant:
+
+```bash
+# Configure downwardApi label path
+export PREVANT_RUNTIME='{downwardApi={labelsPath="/random"}}'
+
+# Use GitLab token to pull images from a private registry
+export PREVANT_REGISTRIES='{"registry.gitlab.com"={username="oauth2",password="your-private-token"}}'
+```
+
+[1]: https://docs.rs/figment/latest/figment/#overview

--- a/api/src/deployment/mod.rs
+++ b/api/src/deployment/mod.rs
@@ -24,7 +24,7 @@
  * =========================LICENSE_END==================================
  */
 
- pub use crate::deployment::deployment_unit::DeploymentUnit;
+pub use crate::deployment::deployment_unit::DeploymentUnit;
 
- pub mod deployment_unit;
- pub mod hooks;
+pub mod deployment_unit;
+pub mod hooks;

--- a/api/src/infrastructure/mod.rs
+++ b/api/src/infrastructure/mod.rs
@@ -28,15 +28,17 @@ use crate::models::Environment;
 pub use docker::DockerInfrastructure as Docker;
 #[cfg(test)]
 pub use dummy_infrastructure::DummyInfrastructure as Dummy;
-pub use infrastructure::{DeploymentStrategy, Infrastructure};
+pub use infrastructure::Infrastructure;
 pub use kubernetes::KubernetesInfrastructure as Kubernetes;
 use serde_json::{map::Map, Value};
+pub use traefik::{TraefikIngressRoute, TraefikRouterRule};
 
 mod docker;
 #[cfg(test)]
 mod dummy_infrastructure;
 mod infrastructure;
 mod kubernetes;
+mod traefik;
 
 static APP_NAME_LABEL: &str = "com.aixigo.preview.servant.app-name";
 static SERVICE_NAME_LABEL: &str = "com.aixigo.preview.servant.service-name";

--- a/api/src/infrastructure/traefik.rs
+++ b/api/src/infrastructure/traefik.rs
@@ -1,0 +1,790 @@
+use crate::models::AppName;
+use pest::Parser;
+use serde_value::Value;
+use std::collections::BTreeMap;
+use std::{fmt::Display, str::FromStr};
+use url::Url;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraefikIngressRoute {
+    entry_points: Vec<String>,
+    routes: Vec<TraefikRoute>,
+    tls: Option<TraefikTLS>,
+}
+
+impl TraefikIngressRoute {
+    pub fn routes(&self) -> &Vec<TraefikRoute> {
+        &self.routes
+    }
+
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self {
+            entry_points: Vec::new(),
+            routes: Vec::new(),
+            tls: None,
+        }
+    }
+
+    pub fn with_defaults(app_name: &AppName, service_name: &str) -> Self {
+        let mut prefixes = BTreeMap::new();
+        prefixes.insert(
+            Value::String(String::from("prefixes")),
+            Value::Seq(vec![Value::String(format!(
+                "/{}/{}/",
+                app_name, service_name
+            ))]),
+        );
+
+        let mut middlewares = BTreeMap::new();
+        middlewares.insert(
+            Value::String(String::from("stripPrefix")),
+            Value::Map(prefixes),
+        );
+
+        Self {
+            entry_points: Vec::new(),
+            routes: vec![TraefikRoute {
+                rule: TraefikRouterRule::path_prefix_rule(&[app_name.as_str(), service_name]),
+                middlewares: vec![TraefikMiddleware::Spec {
+                    name: format!("{app_name}-{service_name}-middleware"),
+                    spec: Value::Map(middlewares),
+                }],
+            }],
+            tls: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_rule(rule: TraefikRouterRule) -> Self {
+        Self::with_existing_routing_rules(Vec::new(), rule, Vec::new(), None)
+    }
+
+    /// Constructs a new [`TraefikIngressRoute`] that is based on existing list of
+    /// [entrypoints](https://doc.traefik.io/traefik/routing/entrypoints/),
+    /// [rules and middlewares](https://doc.traefik.io/traefik/routing/routers/), and
+    /// existng [TLS cert resolver](https://doc.traefik.io/traefik/routing/routers/#certresolver).
+    pub fn with_existing_routing_rules(
+        entry_points: Vec<String>,
+        rule: TraefikRouterRule,
+        middlewares: Vec<String>,
+        cert_resolver: Option<String>,
+    ) -> Self {
+        let middlewares = middlewares
+            .into_iter()
+            .map(TraefikMiddleware::Ref)
+            .collect::<Vec<_>>();
+
+        Self {
+            entry_points,
+            routes: vec![TraefikRoute { rule, middlewares }],
+            tls: cert_resolver.map(|cert_resolver| TraefikTLS { cert_resolver }),
+        }
+    }
+
+    pub fn merge_with(&mut self, other: Self) {
+        self.entry_points.extend(other.entry_points.into_iter());
+
+        // FIXME: at the moment there is no handling of multiple routes which needs to be addessed
+        // in the future when it is required.
+        match (
+            self.routes.iter_mut().next(),
+            other.routes.into_iter().next(),
+        ) {
+            (None, None) => {}
+            (None, Some(route)) => {
+                self.routes.push(route);
+            }
+            (Some(_), None) => {}
+            (Some(route1), Some(route2)) => {
+                route1.rule.merge_with(route2.rule);
+                route1.middlewares.extend(route2.middlewares);
+            }
+        };
+
+        self.tls = match (self.tls.take(), other.tls) {
+            (None, None) => None,
+            (Some(tls), None) => Some(tls),
+            (None, Some(tls)) => Some(tls),
+            (Some(_), Some(tls)) => Some(tls),
+        };
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraefikRoute {
+    rule: TraefikRouterRule,
+    middlewares: Vec<TraefikMiddleware>,
+}
+
+impl TraefikRoute {
+    pub fn rule(&self) -> &TraefikRouterRule {
+        &self.rule
+    }
+
+    pub fn middlewares(&self) -> &Vec<TraefikMiddleware> {
+        &self.middlewares
+    }
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TraefikRouterRule {
+    matches: Vec<Matcher>,
+}
+
+impl TraefikRouterRule {
+    fn path_prefix_from_segments<S>(segments: S) -> String
+    where
+        S: IntoIterator,
+        S::Item: AsRef<str>,
+    {
+        let mut base = Url::parse("https://example.com").expect(
+            "This should never happen: the URL should be parsebale because it is fixed string",
+        );
+
+        let segments = segments.into_iter().flat_map(|seg| {
+            Url::parse(&format!(
+                "https://example.com/{}",
+                seg.as_ref().trim_matches('/')
+            ))
+            .unwrap()
+            .path_segments()
+            .unwrap()
+            .map(|s| s.to_owned())
+            .collect::<Vec<_>>()
+        });
+
+        base.path_segments_mut()
+            .expect("URL shoud be a base")
+            .extend(segments);
+
+        format!("/{}/", base.path().trim_matches('/'))
+    }
+
+    #[cfg(test)]
+    pub fn host_rule(domains: Vec<String>) -> Self {
+        Self {
+            matches: vec![Matcher::Host { domains }],
+        }
+    }
+
+    pub fn path_prefix_rule<S>(segments: S) -> Self
+    where
+        S: IntoIterator,
+        S::Item: AsRef<str>,
+    {
+        Self {
+            matches: vec![Matcher::PathPrefix {
+                paths: vec![Self::path_prefix_from_segments(segments)],
+            }],
+        }
+    }
+
+    pub fn merge_with(&mut self, other: TraefikRouterRule) {
+        for other_match in other.matches {
+            match other_match {
+                Matcher::Headers { key, value } => {
+                    self.matches.push(Matcher::Headers { key, value });
+                }
+                Matcher::Host {
+                    domains: other_domains,
+                } => {
+                    let mut has_domains = false;
+                    for own_matches in self.matches.iter_mut() {
+                        if let Matcher::Host {
+                            domains: ref mut own_domains,
+                        } = own_matches
+                        {
+                            has_domains = true;
+                            own_domains.extend(other_domains.iter().cloned());
+                        }
+                    }
+
+                    if !has_domains {
+                        self.matches.push(Matcher::Host {
+                            domains: other_domains,
+                        });
+                    }
+                }
+                Matcher::PathPrefix { paths: other_paths } => {
+                    let mut has_path_prefixes = false;
+                    for own_matches in self.matches.iter_mut() {
+                        if let Matcher::PathPrefix {
+                            paths: ref mut own_paths,
+                        } = own_matches
+                        {
+                            has_path_prefixes = true;
+
+                            *own_paths = own_paths
+                                .iter()
+                                .flat_map(|own_path| {
+                                    other_paths.iter().map(move |other_path| {
+                                        Self::path_prefix_from_segments(&[
+                                            own_path.as_str(),
+                                            other_path.as_str(),
+                                        ])
+                                    })
+                                })
+                                .collect::<Vec<_>>();
+                        }
+                    }
+
+                    if !has_path_prefixes {
+                        self.matches
+                            .push(Matcher::PathPrefix { paths: other_paths });
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TraefikMiddleware {
+    /// This refers to an existing middleware within the cluster
+    Ref(String),
+    /// This provides a container possible values that are defined [in the Traefik Middleware
+    /// specification](https://doc.traefik.io/traefik/middlewares/http/overview/).
+    Spec {
+        name: String,
+        spec: serde_value::Value,
+    },
+}
+
+#[derive(pest_derive::Parser)]
+#[grammar_inline = r#"
+ident = { (ASCII_ALPHANUMERIC | PUNCTUATION)+ }
+
+Root = _{ (Headers | Host | PathPrefix) ~ ( " "* ~ "&&" ~ " "* ~ (Headers | Host | PathPrefix))* }
+
+Headers = { "Headers" ~ "(`" ~ ident ~ "`, `" ~ ident ~ "`)"  }
+Host = { "Host" ~ "(`" ~ ident ~ ("`, `" ~ ident)* ~ "`)" }
+PathPrefix = { "PathPrefix" ~ "(`" ~ ident ~ ("`, `" ~ ident)* ~ "`)" }
+"#]
+struct RuleParser;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Matcher {
+    Headers { key: String, value: String },
+    Host { domains: Vec<String> },
+    PathPrefix { paths: Vec<String> },
+}
+
+impl FromStr for TraefikRouterRule {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut rule = TraefikRouterRule {
+            matches: Vec::new(),
+        };
+
+        let pairs = RuleParser::parse(Rule::Root, s).map_err(|e| e.to_string())?;
+
+        for pair in pairs {
+            match pair.as_rule() {
+                Rule::Headers => {
+                    let key_and_value = pair
+                        .into_inner()
+                        .map(|pair| pair.as_str())
+                        .collect::<Vec<_>>();
+
+                    rule.matches.push(Matcher::Headers {
+                        key: key_and_value[0].to_string(),
+                        value: key_and_value[1].to_string(),
+                    });
+                }
+                Rule::Host => {
+                    let domains = pair
+                        .into_inner()
+                        .map(|pair| pair.as_str().to_string())
+                        .collect::<Vec<_>>();
+
+                    rule.matches.push(Matcher::Host { domains });
+                }
+                Rule::PathPrefix => {
+                    let paths = pair
+                        .into_inner()
+                        .map(|pair| pair.as_str().to_string())
+                        .collect::<Vec<_>>();
+
+                    rule.matches.push(Matcher::PathPrefix { paths });
+                }
+                Rule::ident | Rule::Root => {}
+            }
+        }
+
+        Ok(rule)
+    }
+}
+
+impl Display for TraefikRouterRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, m) in self.matches.iter().enumerate() {
+            if i > 0 {
+                write!(f, " && ")?;
+            }
+            match m {
+                Matcher::Headers { key, value } => {
+                    write!(f, "Headers(`{key}`, `{value}`)")?;
+                }
+                Matcher::Host { domains } => {
+                    write!(f, "Host(")?;
+
+                    for (i, domain) in domains.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", `{domain}`")?;
+                        } else {
+                            write!(f, "`{domain}`")?;
+                        }
+                    }
+
+                    write!(f, ")")?;
+                }
+                Matcher::PathPrefix { paths } => {
+                    write!(f, "PathPrefix(")?;
+
+                    for (i, domain) in paths.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", `{domain}`")?;
+                        } else {
+                            write!(f, "`{domain}`")?;
+                        }
+                    }
+
+                    write!(f, ")")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraefikTLS {
+    cert_resolver: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sound_failing() {
+        let result = "Random String".parse::<TraefikRouterRule>();
+
+        assert!(std::matches!(result, Err(_)));
+    }
+
+    #[test]
+    fn parse_header_rule() {
+        let rule = "Headers(`Host`, `example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![Matcher::Headers {
+                    key: String::from("Host"),
+                    value: String::from("example.com"),
+                }]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_host_rule() {
+        let rule = "Host(`example.com`)".parse::<TraefikRouterRule>().unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![Matcher::Host {
+                    domains: vec![String::from("example.com")]
+                }]
+            }
+        )
+    }
+
+    #[test]
+    fn parse_hosts_rule() {
+        let rule = "Host(`example.com`, `api.example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![Matcher::Host {
+                    domains: vec![String::from("example.com"), String::from("api.example.com")]
+                }]
+            }
+        )
+    }
+
+    #[test]
+    fn parse_path_prefix_rule() {
+        let rule = "PathPrefix(`/test`)".parse::<TraefikRouterRule>().unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![Matcher::PathPrefix {
+                    paths: vec![String::from("/test")]
+                }]
+            }
+        )
+    }
+
+    #[test]
+    fn parse_path_prefixes_rules() {
+        let rule = "PathPrefix(`/articles`, `/products`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![Matcher::PathPrefix {
+                    paths: vec![String::from("/articles"), String::from("/products")]
+                }]
+            }
+        )
+    }
+
+    #[test]
+    fn parse_path_prefix_and_host_rule() {
+        let rule = "PathPrefix(`/articles`) && Host(`example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(
+            rule,
+            TraefikRouterRule {
+                matches: vec![
+                    Matcher::PathPrefix {
+                        paths: vec![String::from("/articles")]
+                    },
+                    Matcher::Host {
+                        domains: vec![String::from("example.com")]
+                    }
+                ]
+            }
+        )
+    }
+
+    #[test]
+    fn display_path_prefixes() {
+        let rule = "PathPrefix(`/articles`, `/products`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(&rule.to_string(), "PathPrefix(`/articles`, `/products`)");
+    }
+
+    #[test]
+    fn display_host() {
+        let rule = TraefikRouterRule::host_rule(vec![
+            String::from("example.com"),
+            String::from("api.example.com"),
+        ]);
+
+        assert_eq!(&rule.to_string(), "Host(`example.com`, `api.example.com`)");
+    }
+
+    #[test]
+    fn display_headers() {
+        let rule = "Headers(`Host`, `example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        assert_eq!(&rule.to_string(), "Headers(`Host`, `example.com`)");
+    }
+
+    #[test]
+    fn display_host_and_path_prefix() {
+        let rule = TraefikRouterRule {
+            matches: vec![
+                Matcher::Host {
+                    domains: vec![String::from("example.com")],
+                },
+                Matcher::PathPrefix {
+                    paths: vec![String::from("/test")],
+                },
+            ],
+        };
+
+        assert_eq!(
+            &rule.to_string(),
+            "Host(`example.com`) && PathPrefix(`/test`)"
+        );
+    }
+
+    #[test]
+    fn merge_path_prefix_rules() {
+        let mut base_prefix_rule = "PathPrefix(`/base`)".parse::<TraefikRouterRule>().unwrap();
+        let path_prefix_rule = "PathPrefix(`/test`)".parse::<TraefikRouterRule>().unwrap();
+
+        base_prefix_rule.merge_with(path_prefix_rule);
+
+        assert_eq!(
+            Ok(base_prefix_rule),
+            "PathPrefix(`/base/test/`)".parse::<TraefikRouterRule>(),
+        );
+    }
+
+    #[test]
+    fn merge_host_path_prefix_rules() {
+        let mut host_rule = "Host(`example.com`)".parse::<TraefikRouterRule>().unwrap();
+        let path_prefix_rule = "PathPrefix(`/test`)".parse::<TraefikRouterRule>().unwrap();
+
+        host_rule.merge_with(path_prefix_rule);
+
+        assert_eq!(
+            host_rule,
+            TraefikRouterRule {
+                matches: vec![
+                    Matcher::Host {
+                        domains: vec![String::from("example.com")],
+                    },
+                    Matcher::PathPrefix {
+                        paths: vec![String::from("/test")]
+                    }
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn merge_host_rules() {
+        let mut host_rule1 = "Host(`example.com`)".parse::<TraefikRouterRule>().unwrap();
+        let host_rule2 = "Host(`sub.example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        host_rule1.merge_with(host_rule2);
+
+        assert_eq!(
+            host_rule1,
+            TraefikRouterRule {
+                matches: vec![Matcher::Host {
+                    domains: vec![String::from("example.com"), String::from("sub.example.com")],
+                },]
+            }
+        );
+    }
+
+    #[test]
+    fn merge_swapped_host_path_prefix_rules() {
+        let host_rule = "Host(`example.com`)".parse::<TraefikRouterRule>().unwrap();
+        let mut path_prefix_rule = "PathPrefix(`/test`)".parse::<TraefikRouterRule>().unwrap();
+
+        path_prefix_rule.merge_with(host_rule);
+
+        assert_eq!(
+            path_prefix_rule,
+            TraefikRouterRule {
+                matches: vec![
+                    Matcher::PathPrefix {
+                        paths: vec![String::from("/test")]
+                    },
+                    Matcher::Host {
+                        domains: vec![String::from("example.com")],
+                    },
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn merge_headers_rules() {
+        let mut headers_rule_1 = "Headers(`Host`, `example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+        let headers_rule_2 = "Headers(`Content-Type`, `application/json`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        headers_rule_1.merge_with(headers_rule_2);
+
+        assert_eq!(
+            headers_rule_1,
+            "Headers(`Host`, `example.com`) && Headers(`Content-Type`, `application/json`)"
+                .parse::<TraefikRouterRule>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn merge_headers_and_path_prefix_rules() {
+        let mut path_prefix_rule = "PathPrefix(`/test`)".parse::<TraefikRouterRule>().unwrap();
+        let headers_rule = "Headers(`Host`, `example.com`)"
+            .parse::<TraefikRouterRule>()
+            .unwrap();
+
+        path_prefix_rule.merge_with(headers_rule);
+
+        assert_eq!(
+            path_prefix_rule,
+            TraefikRouterRule {
+                matches: vec![
+                    Matcher::PathPrefix {
+                        paths: vec![String::from("/test")]
+                    },
+                    Matcher::Headers {
+                        key: String::from("Host"),
+                        value: String::from("example.com"),
+                    },
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn merge_ingress_routes() {
+        let mut route1 = TraefikIngressRoute {
+            entry_points: vec![String::from("web")],
+            routes: vec![TraefikRoute {
+                rule: TraefikRouterRule::host_rule(vec![String::from("prevant.example.com")]),
+                middlewares: vec![TraefikMiddleware::Ref(String::from("traefik-forward-auth"))],
+            }],
+            tls: Some(TraefikTLS {
+                cert_resolver: String::from("letsencrypt"),
+            }),
+        };
+        let route2 =
+            TraefikIngressRoute::with_defaults(&AppName::from_str("master").unwrap(), "whoami");
+
+        route1.merge_with(route2);
+
+        assert_eq!(
+            route1,
+            TraefikIngressRoute {
+                entry_points: vec![String::from("web")],
+                routes: vec![TraefikRoute {
+                    rule: TraefikRouterRule::from_str(
+                        "Host(`prevant.example.com`) && PathPrefix(`/master/whoami/`)"
+                    )
+                    .unwrap(),
+                    middlewares: vec![
+                        TraefikMiddleware::Ref(String::from("traefik-forward-auth")),
+                        TraefikMiddleware::Spec {
+                            name: String::from("master-whoami-middleware"),
+                            spec: Value::Map(BTreeMap::from([(
+                                Value::String(String::from("stripPrefix")),
+                                Value::Map(BTreeMap::from([(
+                                    Value::String(String::from("prefixes")),
+                                    Value::Seq(vec![Value::String(String::from(
+                                        "/master/whoami/"
+                                    ))])
+                                )]))
+                            )]))
+                        }
+                    ],
+                }],
+                tls: Some(TraefikTLS {
+                    cert_resolver: String::from("letsencrypt"),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn merge_ingress_routes_reverse() {
+        let route1 = TraefikIngressRoute {
+            entry_points: vec![String::from("web")],
+            routes: vec![TraefikRoute {
+                rule: TraefikRouterRule::host_rule(vec![String::from("prevant.example.com")]),
+                middlewares: vec![TraefikMiddleware::Ref(String::from("traefik-forward-auth"))],
+            }],
+            tls: Some(TraefikTLS {
+                cert_resolver: String::from("letsencrypt"),
+            }),
+        };
+        let mut route2 =
+            TraefikIngressRoute::with_defaults(&AppName::from_str("master").unwrap(), "whoami");
+
+        route2.merge_with(route1);
+
+        assert_eq!(
+            route2,
+            TraefikIngressRoute {
+                entry_points: vec![String::from("web")],
+                routes: vec![TraefikRoute {
+                    rule: TraefikRouterRule::from_str(
+                        "PathPrefix(`/master/whoami/`) && Host(`prevant.example.com`)"
+                    )
+                    .unwrap(),
+                    middlewares: vec![
+                        TraefikMiddleware::Spec {
+                            name: String::from("master-whoami-middleware"),
+                            spec: Value::Map(BTreeMap::from([(
+                                Value::String(String::from("stripPrefix")),
+                                Value::Map(BTreeMap::from([(
+                                    Value::String(String::from("prefixes")),
+                                    Value::Seq(vec![Value::String(String::from(
+                                        "/master/whoami/"
+                                    ))])
+                                )]))
+                            )]))
+                        },
+                        TraefikMiddleware::Ref(String::from("traefik-forward-auth")),
+                    ],
+                }],
+                tls: Some(TraefikTLS {
+                    cert_resolver: String::from("letsencrypt"),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn merge_empty_ingress_routes() {
+        let mut route1 = TraefikIngressRoute::empty();
+        let route2 = TraefikIngressRoute::empty();
+
+        route1.merge_with(route2);
+
+        assert_eq!(route1, TraefikIngressRoute::empty());
+    }
+
+    #[test]
+    fn merge_empty_with_none_empty_ingress_routes() {
+        let mut route1 = TraefikIngressRoute::empty();
+
+        route1.merge_with(TraefikIngressRoute::with_defaults(
+            &AppName::from_str("master").unwrap(),
+            "test",
+        ));
+
+        assert_eq!(
+            route1,
+            TraefikIngressRoute::with_defaults(&AppName::from_str("master").unwrap(), "test",)
+        );
+    }
+
+    #[test]
+    fn merge_two_existing_tls_configs() {
+        let mut route1 = TraefikIngressRoute::empty();
+        route1.tls = Some(TraefikTLS {
+            cert_resolver: String::from("first"),
+        });
+        let mut route2 = TraefikIngressRoute::empty();
+        route2.tls = Some(TraefikTLS {
+            cert_resolver: String::from("second"),
+        });
+
+        route1.merge_with(route2);
+
+        assert_eq!(
+            route1,
+            TraefikIngressRoute {
+                entry_points: Vec::new(),
+                routes: Vec::new(),
+                tls: Some(TraefikTLS {
+                    cert_resolver: String::from("second")
+                })
+            }
+        );
+    }
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -35,7 +35,7 @@ extern crate serde_derive;
 
 use crate::apps::host_meta_crawling;
 use crate::apps::Apps;
-use crate::config::{Config, Type};
+use crate::config::{Config, Runtime};
 use crate::infrastructure::{Docker, Infrastructure, Kubernetes};
 use crate::models::request_info::RequestInfo;
 use clap::Parser;
@@ -78,11 +78,11 @@ fn openapi(request_info: RequestInfo) -> Option<String> {
 
 fn create_infrastructure(config: &Config) -> Box<dyn Infrastructure> {
     match config.runtime_config() {
-        Type::Docker => {
+        Runtime::Docker => {
             log::info!("Using Docker backend");
             Box::new(Docker::new(config.clone()))
         }
-        Type::Kubernetes => {
+        Runtime::Kubernetes(_config) => {
             log::info!("Using Kubernetes backend");
             Box::new(Kubernetes::new(config.clone()))
         }

--- a/api/src/models/service_config/mod.rs
+++ b/api/src/models/service_config/mod.rs
@@ -156,13 +156,6 @@ impl ServiceConfig {
         }
     }
 
-    pub fn traefik_rule(&self, app_name: &String) -> String {
-        match &self.router {
-            None => format!("PathPrefix(`/{}/{}/`)", app_name, &self.service_name),
-            Some(router) => router.rule.clone(),
-        }
-    }
-
     pub fn set_middlewares(&mut self, middlewares: BTreeMap<String, Value>) {
         self.middlewares = Some(middlewares);
     }
@@ -171,27 +164,6 @@ impl ServiceConfig {
         match &self.middlewares {
             None => None,
             Some(middlewares) => Some(middlewares),
-        }
-    }
-
-    pub fn traefik_middlewares<'a, 'b: 'a>(&'b self, app_name: &String) -> BTreeMap<String, Value> {
-        match &self.middlewares {
-            None => {
-                let mut prefixes = BTreeMap::new();
-                prefixes.insert(
-                    Value::String("prefixes".to_string()),
-                    Value::Seq(vec![Value::String(format!(
-                        "/{}/{}/",
-                        app_name, self.service_name
-                    ))]),
-                );
-
-                let mut middlewares = BTreeMap::new();
-                middlewares.insert("stripPrefix".to_string(), Value::Map(prefixes));
-
-                middlewares
-            }
-            Some(middlewares) => middlewares.clone(),
         }
     }
 
@@ -232,16 +204,13 @@ pub struct Router {
 }
 
 impl Router {
+    #[cfg(test)]
     pub fn new(rule: String, priority: Option<i32>) -> Self {
         Router { rule, priority }
     }
 
     pub fn rule(&self) -> &String {
         &self.rule
-    }
-
-    pub fn priority(&self) -> &Option<i32> {
-        &self.priority
     }
 
     pub fn with_rule(&self, rule: String) -> Self {

--- a/examples/Kubernetes/PREvant.yml
+++ b/examples/Kubernetes/PREvant.yml
@@ -46,6 +46,17 @@ spec:
           ports:
             - name: web
               containerPort: 80
+          volumeMounts:
+            - name: podinfo
+              mountPath: /run/podinfo/
+              readOnly: true
+      volumes:
+        - name: podinfo
+          downwardAPI:
+             items:
+               - path: "labels"
+                 fieldRef:
+                    fieldPath: metadata.labels
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute


### PR DESCRIPTION
When a new service will be deployed to underlying infrastructure, PREvant will ask the infrastructure which Traefik routing options are assigned to PREvant itself and if the infrastructure is able to determine this routing information, PREvant will merge this information with services routing information.

This feature is currently only implemented for Kubernetes and uses Kubernetes' downwardAPI. A label file has to be mounted into the deployemnt (by default it is `/run/podinfo/labels`) and it then queries the Kubernetes API for all Traefik ingresses that match these labels.

Additionally, the commit improves Docker build caching for having faster, local development turn around times.

Fixes #108 