### PR TITLE
Fixed URL Generation Not Taking Forwarded Header Into Account 

### DIFF
--- a/api/src/config/secret.rs
+++ b/api/src/config/secret.rs
@@ -24,7 +24,7 @@
  * =========================LICENSE_END==================================
  */
 use crate::config::AppSelector;
-use base64::{Engine, engine::general_purpose};
+use base64::{engine::general_purpose, Engine};
 use secstr::SecUtf8;
 use serde::{de, Deserialize, Deserializer};
 use std::path::PathBuf;
@@ -46,7 +46,9 @@ impl Secret {
         D: Deserializer<'de>,
     {
         let secret = String::deserialize(deserializer)?;
-        let decoded = general_purpose::STANDARD.decode(&secret).map_err(de::Error::custom)?;
+        let decoded = general_purpose::STANDARD
+            .decode(&secret)
+            .map_err(de::Error::custom)?;
         let sec_value = String::from_utf8(decoded).map_err(de::Error::custom)?;
         Ok(SecUtf8::from(sec_value))
     }

--- a/api/src/infrastructure/kubernetes/payloads.rs
+++ b/api/src/infrastructure/kubernetes/payloads.rs
@@ -32,7 +32,7 @@ use crate::infrastructure::traefik::TraefikMiddleware;
 use crate::infrastructure::{TraefikIngressRoute, TraefikRouterRule};
 use crate::models::service::Service;
 use crate::models::ServiceConfig;
-use base64::{Engine, engine::general_purpose};
+use base64::{engine::general_purpose, Engine};
 use chrono::Utc;
 use k8s_openapi::api::apps::v1::DeploymentSpec;
 use k8s_openapi::api::core::v1::{


### PR DESCRIPTION
Added and fixed code which takes into account the forwarded headers specifically x-forwarded-host, x-forwarded-proto and x-forwarded port. The url doesn't break any more and works with the required protocols.

Fixes #109 