### PR TITLE
Persistence Hooks for Storage Path Management

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -200,11 +200,11 @@ storageStrategy = 'mount-declared-image-volumes'
 - `none` (_default_): Companion is deployed without persistent storage.
 - `mount-declared-image-volumes`: Mounts the volume paths declared within the image, providing persistent storage for the companion.
 
-## Hooks
+## Deployment Hooks
 
-Hooks can be used to manipulate the deployment before handing it over to actual infrastructure and they are able to manipulate all service configurations once for any deployment REST API call. For example, based on the deployment's app name you can decide to reconfigure your services to use a different DBMS so that you are able to verify that your services work with different DBMSs.
+Deployment Hooks can be used to manipulate the deployment before handing it over to actual infrastructure and they are able to manipulate all service configurations once for any deployment REST API call. For example, based on the deployment's app name you can decide to reconfigure your services to use a different DBMS so that you are able to verify that your services work with different DBMSs.
 
-Technically, hooks are Javascript files that provide functions to modify all service configurations of a deployment. For example, add following section to your PREvant configuration. This configuration snippet enables the _deployemnt hook_ that will be used to modify the services' configurations.
+Technically, hooks are Javascript files that provide functions to modify all service configurations of a deployment. For example, add following section to your PREvant configuration. This configuration snippet enables the _deployment hook_ that will be used to modify the services' configurations.
 
 ```toml
 [hooks]
@@ -232,6 +232,34 @@ PREvant calls this function with the app name (see `appName`) and an array of se
 | `type`        | The type of the service, e.g. `instance`, `replica`, etc. (readonly).                                      |
 | `env`         | A map of key and value containing the environment variables that will be used when creating the container. |
 | `files`       | A map of key and value containing the files that will be mounted into the container.                       |
+
+## Persistence Hooks
+Persistence Hooks in PREvant are designed to handle data persistence by managing volume paths of services. For example, you can use a Persistence Hook to configure any services that share a persistence path or add missing additional paths that caters to unreleased features.
+
+Like Deployment Hooks, these hooks are Javascript files that provide functions to manage and manipulate persistence settings. This configuration snippet enables the _persistence hook_ that will be used to modify the services' configurations.
+
+```toml
+[hooks]
+persistence = 'path/to/persistenceHook.js'
+```
+
+The hook at `path/to/hook.js` must provide following Javascript function:
+
+```javascript
+function persistenceHook(appName, serviceConfigs) {
+  //Return Array of an Array of pairs of service name and path.
+}
+```
+Note: The input to the Persistence Hook is an array of name and path pairs. If multiple paths are declared in the configuration, they are split and treated as separate pairs.
+
+PREvant will invoke this function with an array of service config with name and path as fields. This input can be modified according to the required persistence logic and must be returned by the function in an Array of Arrays format. The output structure allows for grouping shared paths or treating them as individual, based on the deployment's specific requirements.
+
+The fields in each object of the serviceConfig are:
+
+| Key           | Description                                                                                                |
+|---------------|------------------------------------------------------------------------------------------------------------|
+| `name`        | The service name (readonly).                                                                               |
+| `path`       | The path declared by the docker manifest of the image file.              |
 
 ## Registries
 

--- a/api/src/apps/mod.rs
+++ b/api/src/apps/mod.rs
@@ -280,7 +280,7 @@ impl AppsService {
             .extend_with_templating_only_service_configs(configs_for_templating)
             .resolve_image_manifest(&self.config)
             .await?
-            .apply_templating()?
+            .apply_templating(&self.config)?
             .apply_hooks(&self.config)
             .await?;
 
@@ -398,6 +398,8 @@ pub enum AppsServiceError {
     UnableToResolveImage { error: ImagesServiceError },
     #[fail(display = "Invalid deployment hook.")]
     InvalidDeploymentHook,
+    #[fail(display = "Invalid persistence hook.")]
+    InvalidPersistenceHook,
 }
 
 impl From<ConfigError> for AppsServiceError {

--- a/api/src/apps/routes.rs
+++ b/api/src/apps/routes.rs
@@ -360,7 +360,8 @@ impl From<AppsError> for HttpApiError {
             | AppsError::InvalidServerConfiguration { .. }
             | AppsError::InvalidTemplateFormat { .. }
             | AppsError::UnableToResolveImage { .. }
-            | AppsError::InvalidDeploymentHook => {
+            | AppsError::InvalidDeploymentHook
+            | AppsError::InvalidPersistenceHook => {
                 error!("Internal server error: {}", error);
                 StatusCode::INTERNAL_SERVER_ERROR
             }

--- a/api/src/deployment/hooks/mod.rs
+++ b/api/src/deployment/hooks/mod.rs
@@ -1,0 +1,56 @@
+use self::deployment_hooks::DeploymentHooks;
+use self::persistence_hooks::PersistenceHooks;
+use super::deployment_unit::{DeployableService, ServicePath};
+use crate::apps::AppsServiceError;
+use crate::{config::Config, models::AppName};
+pub mod deployment_hooks;
+pub mod persistence_hooks;
+
+pub struct Hooks<'a> {
+    hook_config: &'a Config,
+}
+
+impl<'a> Hooks<'a> {
+    pub fn new(hook_config: &'a Config) -> Self {
+        Hooks { hook_config }
+    }
+
+    pub async fn apply_deployment_hook(
+        &self,
+        app_name: &AppName,
+        services: Vec<DeployableService>,
+    ) -> Result<Vec<DeployableService>, AppsServiceError> {
+        match self.hook_config.hook("deployment") {
+            None => Ok(services),
+            Some(hook_path) => {
+                DeploymentHooks::parse_and_run_hook(app_name, services, hook_path).await
+            }
+        }
+    }
+
+    pub async fn apply_persistence_hooks(
+        &self,
+        app_name: &AppName,
+        services: &Vec<DeployableService>,
+    ) -> Result<Vec<Vec<ServicePath>>, AppsServiceError> {
+        match self.hook_config.hook("persistence") {
+            None => Ok(Hooks::default_persistence_structure(services)),
+            Some(hook_path) => {
+                PersistenceHooks::parse_and_run_hook(app_name, services, hook_path).await
+            }
+        }
+    }
+
+    pub fn default_persistence_structure(services: &[DeployableService]) -> Vec<Vec<ServicePath>> {
+        let mut default_persistence = Vec::new();
+        services.iter().for_each(|s| {
+            s.declared_volumes().iter().for_each(|v| {
+                default_persistence.push(vec![ServicePath::new(
+                    s.service_name().to_string(),
+                    v.to_string(),
+                )]);
+            })
+        });
+        default_persistence
+    }
+}

--- a/api/src/deployment/hooks/persistence_hooks.rs
+++ b/api/src/deployment/hooks/persistence_hooks.rs
@@ -1,0 +1,450 @@
+/*-
+ * ========================LICENSE_START=================================
+ * PREvant REST API
+ * %%
+ * Copyright (C) 2018 - 2021 aixigo AG
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+
+use crate::apps::AppsServiceError;
+use crate::deployment::deployment_unit::{DeployableService, ServicePath};
+use crate::models::AppName;
+use boa_engine::property::Attribute;
+use boa_engine::{Context, JsValue, Source};
+use std::path::Path;
+
+use super::Hooks;
+
+pub struct PersistenceHooks;
+
+impl PersistenceHooks {
+    pub async fn parse_and_run_hook(
+        app_name: &AppName,
+        services: &[DeployableService],
+        hook_path: &Path,
+    ) -> Result<Vec<Vec<ServicePath>>, AppsServiceError> {
+        match Self::parse_hook(hook_path).await {
+            Some(mut context) => {
+                Self::register_configs_as_global_property(&mut context, services);
+                context
+                    .register_global_property(
+                        "appName",
+                        JsValue::String(app_name.to_string().into()),
+                        Attribute::READONLY,
+                    )
+                    .expect("Property registration failed unexpectedly");
+
+                let transformed_configs = context
+                    .eval(Source::from_bytes(
+                        "persistenceHook(appName, serviceConfigs)",
+                    ))
+                    .unwrap();
+
+                let transformed_configs = transformed_configs.to_json(&mut context).unwrap();
+                Self::parse_service_config(transformed_configs)
+            }
+            None => Ok(Hooks::default_persistence_structure(services)),
+        }
+    }
+
+    async fn parse_hook(hook_path: &Path) -> Option<Context> {
+        let hook_content = match tokio::fs::read_to_string(hook_path).await {
+            Ok(hook_content) => hook_content,
+            Err(err) => {
+                error!("Cannot read hook file {:?}: {}", hook_path, err);
+                return None;
+            }
+        };
+
+        let mut context = Context::default();
+
+        if let Err(err) = context.eval(Source::from_bytes(&hook_content)) {
+            error!(
+                "Cannot populate hook {:?} to Javascript context: {:?}",
+                hook_path, err
+            );
+            return None;
+        }
+
+        if dbg!(context.interner().get("persistenceHook")).is_some() {
+            Some(context)
+        } else {
+            None
+        }
+    }
+
+    fn register_configs_as_global_property(context: &mut Context, services: &[DeployableService]) {
+        let js_configs = services
+            .iter()
+            .flat_map(|service| match service.declared_volumes().is_empty() {
+                true => vec![JsPersistenceConfig::new(service.service_name(), None)],
+                false => service
+                    .declared_volumes()
+                    .iter()
+                    .map(|volume| JsPersistenceConfig::new(service.service_name(), Some(volume)))
+                    .collect::<Vec<_>>(),
+            })
+            .collect::<Vec<_>>();
+        let js_configs = serde_json::to_value(js_configs).expect("Should be serializable");
+        let js_configs =
+            JsValue::from_json(&js_configs, context).expect("Unable to read JSON value");
+
+        context
+            .register_global_property("serviceConfigs", js_configs, Attribute::READONLY)
+            .expect("Property registration failed unexpectedly");
+    }
+
+    fn parse_service_config(
+        transformed_configs: serde_json::value::Value,
+    ) -> Result<Vec<Vec<ServicePath>>, AppsServiceError> {
+        serde_json::from_value::<Vec<Vec<ServicePath>>>(transformed_configs).map_err(|err| {
+            error!("Cannot parse result of persistence hook: {}", err);
+            AppsServiceError::InvalidPersistenceHook
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsPersistenceConfig {
+    name: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+impl JsPersistenceConfig {
+    fn new(name: &str, path: Option<&str>) -> Self {
+        Self {
+            name: name.to_string(),
+            path: path.map(|s| s.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::apps::*;
+    use crate::config::Config;
+    use crate::deployment::deployment_unit::DeploymentStrategy;
+    use crate::deployment::hooks::Hooks;
+    use crate::infrastructure::TraefikIngressRoute;
+    use std::io::Write;
+    use std::str::FromStr;
+    use std::vec;
+    use tempfile::NamedTempFile;
+
+    fn config_with_persistence_hook(script: &str) -> (NamedTempFile, Config) {
+        let mut hook_file = NamedTempFile::new().unwrap();
+
+        hook_file.write_all(script.as_bytes()).unwrap();
+
+        let config = crate::config_from_str!(&format!(
+            r#"
+            [hooks]
+            persistence = {:?}
+            "#,
+            hook_file.path()
+        ));
+
+        (hook_file, config)
+    }
+
+    #[tokio::test]
+    async fn apply_persistence_hook_to_share_volumes() -> Result<(), AppsError> {
+        let script = r#"
+        function persistenceHook(appName, configs) {
+            let sharedGroups = [
+                [
+                    { serviceName: "service-a", path: "/var/lib/data" },
+                    { serviceName: "service-b", path: "/var/lib/data" }
+                ],
+                [
+                    { serviceName: "service-a", path: "/var/lib/cache" },
+                    { serviceName: "service-c", path: "/var/lib/cache" }
+                ]
+            ];
+            let result = sharedGroups.map(() => []);
+            configs.forEach(config => {
+                let matched = false;
+                sharedGroups.forEach((group, groupIndex) => {
+                    if (group.some(pair => pair.serviceName === config.name && pair.path === config.path)) {
+                        result[groupIndex].push({ serviceName: config.name, path: config.path });
+                        matched = true;
+                    }
+                });
+            });
+            return result.filter(group => group.length > 0);
+        }        
+        "#;
+
+        let (_temp_js_file, config) = config_with_persistence_hook(script);
+
+        let persistence_hooks = Hooks::new(&config);
+        let services = vec![
+            crate::sc!("service-a"),
+            crate::sc!("service-b"),
+            crate::sc!("service-c"),
+        ];
+        let deployable_services = services
+            .into_iter()
+            .map(|service| {
+                DeployableService::new(
+                    service,
+                    DeploymentStrategy::RedeployAlways,
+                    TraefikIngressRoute::empty(),
+                    vec![
+                        String::from("/var/lib/data"),
+                        String::from("/var/lib/cache"),
+                    ],
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = persistence_hooks
+            .apply_persistence_hooks(&AppName::from_str("master").unwrap(), &deployable_services)
+            .await?;
+
+        assert_eq!(
+            result,
+            vec![
+                vec![
+                    ServicePath::new(String::from("service-a"), String::from("/var/lib/data")),
+                    ServicePath::new(String::from("service-b"), String::from("/var/lib/data"))
+                ],
+                vec![
+                    ServicePath::new(String::from("service-a"), String::from("/var/lib/cache")),
+                    ServicePath::new(String::from("service-c"), String::from("/var/lib/cache"))
+                ]
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_persistence_hook_to_add_missing_volumes() -> Result<(), AppsError> {
+        let script = r#"
+        function persistenceHook( appName, configs ) {
+            let result = [];
+            configs.forEach(config => {
+                [{serviceName: "service-a", path: "/var/lib/data"}].forEach(volume => {
+                    if (volume.serviceName === config.name) {
+                        result.push([{ serviceName: volume.serviceName, path: volume.path }]);
+                    }
+                });
+            })
+
+            return result;
+        }
+        "#;
+
+        let (_temp_js_file, config) = config_with_persistence_hook(script);
+
+        let persistence_hooks = Hooks::new(&config);
+        let deployable_services = vec![DeployableService::new(
+            crate::sc!("service-a"),
+            DeploymentStrategy::RedeployNever,
+            TraefikIngressRoute::empty(),
+            Vec::new(),
+        )];
+
+        let result = persistence_hooks
+            .apply_persistence_hooks(&AppName::from_str("master").unwrap(), &deployable_services)
+            .await?;
+
+        assert_eq!(
+            result,
+            vec![vec![ServicePath::new(
+                String::from("service-a"),
+                String::from("/var/lib/data")
+            )]]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fail_with_persistence_hook_returning_invalid_object() -> Result<(), AppsError> {
+        let script = r#"
+        function persistenceHook( appName, configs ) {
+            return 'unexpected return value';
+        }        
+        "#;
+
+        let (_temp_js_file, config) = config_with_persistence_hook(script);
+
+        let persistence_hooks = Hooks::new(&config);
+        let deployable_services = DeployableService::new(
+            crate::sc!("service-a"),
+            DeploymentStrategy::RedeployAlways,
+            TraefikIngressRoute::empty(),
+            vec![
+                String::from("/var/lib/data"),
+                String::from("/var/lib/cache"),
+            ],
+        );
+
+        let mut persistence_hook_error = String::new();
+        match persistence_hooks
+            .apply_persistence_hooks(
+                &AppName::from_str("master").unwrap(),
+                &vec![deployable_services],
+            )
+            .await
+        {
+            Ok(result) => Some(result),
+            Err(err) => {
+                persistence_hook_error = err.to_string();
+                None
+            }
+        };
+
+        assert_eq!(
+            persistence_hook_error,
+            String::from("Invalid persistence hook.")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_persistence_hook_to_delete_declared_volumes() -> Result<(), AppsError> {
+        let script = r#"
+        function persistenceHook(appName, configs) {
+            let result = [];
+            for (const config of configs) {
+                for (const volume of [{ serviceName: "service-a", path: "/var/lib/data" }]) {
+                    if (volume.serviceName === config.name && volume.path === config.path) {
+                        break;
+                    } else {
+                        result.push([{ serviceName: config.name, path: config.path }]);
+                    }
+                }
+            }
+            return result;
+        }
+             
+        "#;
+
+        let (_temp_js_file, config) = config_with_persistence_hook(script);
+
+        let persistence_hooks = Hooks::new(&config);
+        let services = vec![crate::sc!("service-a"), crate::sc!("service-b")];
+
+        let deployable_services = services
+            .into_iter()
+            .map(|service| {
+                DeployableService::new(
+                    service,
+                    DeploymentStrategy::RedeployAlways,
+                    TraefikIngressRoute::empty(),
+                    vec![
+                        String::from("/var/lib/data"),
+                        String::from("/var/lib/cache"),
+                    ],
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = persistence_hooks
+            .apply_persistence_hooks(&AppName::from_str("master").unwrap(), &deployable_services)
+            .await?;
+
+        assert_eq!(
+            result,
+            vec![
+                vec![ServicePath::new(
+                    "service-a".to_string(),
+                    "/var/lib/cache".to_string()
+                )],
+                vec![ServicePath::new(
+                    "service-b".to_string(),
+                    "/var/lib/data".to_string()
+                )],
+                vec![ServicePath::new(
+                    "service-b".to_string(),
+                    "/var/lib/cache".to_string()
+                )]
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn default_persistence_structure_in_case_of_missing_persistence_hook(
+    ) -> Result<(), AppsError> {
+        let script = r#"
+        function deploymentHook(appName, configs) {
+            return configs;
+        }   
+        "#;
+
+        let (_temp_js_file, config) = config_with_persistence_hook(script);
+
+        let persistence_hooks = Hooks::new(&config);
+        let services = vec![crate::sc!("service-a"), crate::sc!("service-b")];
+
+        let deployable_services = services
+            .into_iter()
+            .map(|service| {
+                DeployableService::new(
+                    service,
+                    DeploymentStrategy::RedeployAlways,
+                    TraefikIngressRoute::empty(),
+                    vec![
+                        String::from("/var/lib/data"),
+                        String::from("/var/lib/cache"),
+                    ],
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let result = persistence_hooks
+            .apply_persistence_hooks(&AppName::from_str("master").unwrap(), &deployable_services)
+            .await?;
+
+        assert_eq!(
+            result,
+            vec![
+                vec![ServicePath::new(
+                    "service-a".to_string(),
+                    "/var/lib/data".to_string()
+                )],
+                vec![ServicePath::new(
+                    "service-a".to_string(),
+                    "/var/lib/cache".to_string()
+                )],
+                vec![ServicePath::new(
+                    "service-b".to_string(),
+                    "/var/lib/data".to_string()
+                )],
+                vec![ServicePath::new(
+                    "service-b".to_string(),
+                    "/var/lib/cache".to_string()
+                )]
+            ]
+        );
+
+        Ok(())
+    }
+}

--- a/api/src/infrastructure/mod.rs
+++ b/api/src/infrastructure/mod.rs
@@ -46,7 +46,7 @@ static CONTAINER_TYPE_LABEL: &str = "com.aixigo.preview.servant.container-type";
 static REPLICATED_ENV_LABEL: &str = "com.aixigo.preview.servant.replicated-env";
 static IMAGE_LABEL: &str = "com.aixigo.preview.servant.image";
 static STATUS_ID: &str = "com.aixigo.preview.servant.status-id";
-static STORAGE_TYPE_LABEL: &str = "com.aixigo.preview.servant.storage-type";
+static SERVICE_PERSISTENCE_LABEL: &str = "com.aixigo.preview.servant.service-persistence";
 
 /// This function converts the environment variables and adds all variables, that
 /// must be replicated, into a JSON object. This function should be used by implementations

--- a/examples/Kubernetes/RBAC-authorization.yml
+++ b/examples/Kubernetes/RBAC-authorization.yml
@@ -59,6 +59,25 @@ rules:
     - update
     - patch
     - delete
+    - apiGroups:
+    - ""
+   resources:  
+    - persistentvolumes
+    - persistentvolumeclaims
+   verbs:
+    - get
+    - list
+    - create
+    - update
+    - patch
+    - delete
+ - apiGroups:
+    - ""
+   resources:  
+    - storageclass
+   verbs:
+    - get
+    - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This feature will allow users to share declared volumes and delete volume paths exposed by the docker manifest with the help of Persistence Hooks.

The hooks also allows adding of any additional volume paths that are undeclared in the image.

Interface
- Input is array service config containing of name and path.
- Functions like sharing persistence paths, adding missing paths, removing existing paths can be performed in the JavaScript Hooks.
- Return from JavaScript to PREvant will be an array of an array where array can contain multiple elements in case of shared and a single element array in case of an individual persistence paths.
- These results are then handled by infrastructure according to the grouping.

Fixes #123 