### PR TITLE
Improve Jira Handling

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -53,6 +53,12 @@ Currently, Jira as a tracking system is supported.
 ```toml
 [jira]
 host = 'https://jira.example.com'
+apiKey = ''
+```
+
+```toml
+[jira]
+host = 'https://jira.example.com'
 user = ''
 password = ''
 ```


### PR DESCRIPTION
Add apiKey option in order to use API Keys instead of username and password.

Additionally, an empty dashboard with active Jira configuration resulted in an HTTP 500 error because the Jira query failed on the Jira API level. If no applications are available, there is no need to query the Jira API.