### PR TITLE
Improved log interface performance and streaming

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -2137,6 +2137,7 @@ name = "prevant"
 version = "0.9.0"
 dependencies = [
  "assert-json-diff",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "boa_engine",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = "0.1"
+async-stream = "0.3"
 base64 = "0.21"
 boa_engine = "0.17"
 bytesize = { version = "1.3", features = ["serde"] }

--- a/api/res/openapi.yml
+++ b/api/res/openapi.yml
@@ -246,12 +246,20 @@ paths:
           example: '2019-07-22T08:42:47-00:00'
         - in: query
           name: limit
-          description: The number of log lines to retrieve. If not present, 1000 lines will be retrieved.
+          description: The number of log lines to retrieve. If not present, all the lines from `since` are retrieved.
           schema:
             type: integer
+        - in: query
+          name: asAttachment
+          description: >-
+            Determines how the response is presented by the browser. When `true`, the response content is provided as a downloadable attachment.
+            If `false` or not provided, the response is displayed inline.
+          schema:
+            type: boolean
       responses:
         '200':
-          description: The available log statements
+          description: | 
+            The available log statements. MIME type `text/event-stream` supports streaming of logs.
           headers:
             Link:
               schema:

--- a/api/src/infrastructure/infrastructure.rs
+++ b/api/src/infrastructure/infrastructure.rs
@@ -32,6 +32,7 @@ use crate::models::{AppName, ContainerType, ServiceConfig};
 use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset};
 use failure::Error;
+use futures::stream::BoxStream;
 use multimap::MultiMap;
 
 #[async_trait]
@@ -68,14 +69,15 @@ pub trait Infrastructure: Send + Sync {
         app_name: &AppName,
     ) -> Result<Vec<Service>, Error>;
 
-    /// Returns the log lines with a the corresponding timestamps in it.
-    async fn get_logs(
-        &self,
-        app_name: &AppName,
-        service_name: &str,
-        from: &Option<DateTime<FixedOffset>>,
-        limit: usize,
-    ) -> Result<Option<Vec<(DateTime<FixedOffset>, String)>>, Error>;
+    /// Streams the log lines with a the corresponding timestamps in it.
+    async fn get_logs<'a>(
+        &'a self,
+        app_name: &'a AppName,
+        service_name: &'a str,
+        from: &'a Option<DateTime<FixedOffset>>,
+        limit: &'a Option<usize>,
+        follow: bool,
+    ) -> BoxStream<'a, Result<(DateTime<FixedOffset>, String), failure::Error>>;
 
     /// Changes the status of a service, for example, the service might me stopped or started.
     async fn change_status(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "current-script-polyfill": "^1.0.0",
         "esprima": "^4.0.1",
         "jquery": "^3.6.0",
-        "moment": "^2.29.1",
+        "moment": "^2.30.1",
         "parse-link-header": "^2.0.0",
         "popper.js": "^1.16.1",
         "swagger-ui": "^4.18.2",
@@ -8011,9 +8011,9 @@
       "dev": true
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -49,13 +49,14 @@ import OpenApiUI from './OpenApiUI.vue';
 import LogsDialog from './LogsDialog.vue';
 
 import {library} from '@fortawesome/fontawesome-svg-core';
-import {faClipboard, faCode, faCopy, faServer, faSpinner, faTerminal, faTrash, faWindowClose} from '@fortawesome/free-solid-svg-icons';
+import {faClipboard, faCode, faCopy, faServer, faSpinner, faTerminal, faTrash, faWindowClose, faDownload} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
 import store from './store';
 
 library.add(faClipboard);
 library.add(faCode);
 library.add(faCopy);
+library.add(faDownload);
 library.add(faServer);
 library.add(faSpinner);
 library.add(faTerminal);


### PR DESCRIPTION
This commit enhances the log interface by reducing lag and improving the rendering speed. It introduces a feature to load the latest logs first and logs are now streamed in real-time from backend, ensuring immediate access to new logs. The infrastructure is now able to handle both streaming and one time log transfer in one function only, avoiding the use of multiple implementations. The routes ensure the output is served to the client based on content negotiation.

Fixes #25