### PR TITLE
Use maintained rust-toolchain instead of actions-rs

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Install latest stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Run cargo test
         run:
@@ -26,7 +26,7 @@ jobs:
         run: docker build --pull -t aixigo/prevant .
 
       - name: Install latest stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Run cargo test
         run:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: Build and test API
 

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -11,6 +11,8 @@ jobs:
 
       - name: Install latest stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
 
       - name: Run cargo test
         run:
@@ -27,6 +29,8 @@ jobs:
 
       - name: Install latest stable
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
 
       - name: Run cargo test
         run:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -10,16 +10,11 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path api/Cargo.toml
+        run:
+          cargo test --manifest-path api/Cargo.toml
 
   integrationTests:
     name: API Integration Tests
@@ -31,13 +26,8 @@ jobs:
         run: docker build --pull -t aixigo/prevant .
 
       - name: Install latest stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path api-tests/Cargo.toml -- --test-threads=1
+        run:
+          cargo test --manifest-path api-tests/Cargo.toml -- --test-threads=1


### PR DESCRIPTION
actions-rs seems to be abandoned (https://github.com/actions-rs) and uses deprecated features which cause warnings in github actions. (Like "The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1")

Use dtolnay/rust-toolchain instead of actions-rs/toolchain, and replace actions-rs/cargo by just calling cargo directly.