### PR TITLE
Avoid Duplicated CI Runs on PRs

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+   push:
+      branches:
+         - master
+   pull_request:
 
 name: Build and test API
 


### PR DESCRIPTION
In #158 the CI workflow has been improved so that CI also runs when providing a PR. However, that led to the situation that CI runs are duplicated for PRs that originate from internal branches. This commit adresses this issues and avoids duplicate CI runs.