### PR TITLE
Make Kubernetes More Robust

### DIFF
--- a/api/src/infrastructure/kubernetes/deployment_unit.rs
+++ b/api/src/infrastructure/kubernetes/deployment_unit.rs
@@ -85,7 +85,13 @@ impl K8sDeploymentUnit {
                     name: format!("bootstrap-{i}"),
                     image: Some(bc.image().to_string()),
                     image_pull_policy: Some(String::from("Always")),
-                    args: Some(bc.templated_args(app_name, &base_url)?),
+                    args: Some(bc.templated_args(
+                        app_name,
+                        &base_url,
+                        Some(serde_json::json!({
+                            "namespace": app_name.to_rfc1123_namespace_id()
+                        })),
+                    )?),
                     ..Default::default()
                 })
             })

--- a/docs/companions.md
+++ b/docs/companions.md
@@ -181,6 +181,10 @@ The list of available handlebars variables for bootstrap container arguments:
 - `application`: The companion's application information
   - `name`: The application name
   - `baseUrl`: The URL that all services in the application share
+- `infrastructure`: Holds information that are specific to the underlying
+  infrastructure.
+  - 'namespace' (Kubernetes): the name of the namespace where the application
+    will be installed in.
 
 [docker-compose]: https://docs.docker.com/compose/
 [handlebars]: https://handlebarsjs.com/


### PR DESCRIPTION
In some cases it is necessary to access the Kubernetes namespace ID in bootstrap container arguments. For example, some Helm charts require that you provide `--namespace` option if a bootstrap container utilizes Helm under the hood. This commit provides `{{infrastructure.namespace}}` template argument for bootstrap container start up

There was also a bug that conversion of ingress routes included multiple `stripPrefix` middlewares when derived from bootstrap containers. The once provided by the bootstrap container must not included the defaults from PREvant and thus have to filtered.

Additionally, there was a bug in the Kubernetes middleware ID generation. Capital letters in the application names caused the deployment to fail because these ID have to be RFC1123 compliant. This commit ensures that names will be generated according to this RFC.