### PR TITLE
Allow Adjustment of Companion Routing

### DIFF
--- a/Develop.md
+++ b/Develop.md
@@ -23,7 +23,7 @@ For developing against a local Kubernetes cluster you can use [k3d](https://k3d.
 2. Start PREvant with Kubernetes (it will infer the cluster configuration by searching for kube-config file or in-cluster environment variables)
 
    ```bash
-   cargo run -- --runtime.type Kubernetes
+   cargo run -- --runtime-type Kubernetes
    ```
 
 3. Deploy some containers and observe the result [here](http://localhost/master/whoami/):

--- a/api/src/apps/mod.rs
+++ b/api/src/apps/mod.rs
@@ -426,6 +426,8 @@ pub enum AppsServiceError {
     UnableToResolveImage { error: RegistryError },
     #[fail(display = "Invalid deployment hook.")]
     InvalidDeploymentHook,
+    #[fail(display = "Failed to parse traefik rule ({}): {}", raw_rule, err)]
+    FailedToParseTraefikRule { raw_rule: String, err: String },
 }
 
 impl From<ConfigError> for AppsServiceError {

--- a/api/src/apps/routes/mod.rs
+++ b/api/src/apps/routes/mod.rs
@@ -290,7 +290,8 @@ impl From<AppsError> for HttpApiError {
             AppsError::AppNotFound { .. } => StatusCode::NOT_FOUND,
             AppsError::AppIsInDeployment { .. } => StatusCode::CONFLICT,
             AppsError::AppIsInDeletion { .. } => StatusCode::CONFLICT,
-            AppsError::InfrastructureError { .. }
+            AppsError::FailedToParseTraefikRule { .. }
+            | AppsError::InfrastructureError { .. }
             | AppsError::InvalidServerConfiguration { .. }
             | AppsError::InvalidTemplateFormat { .. }
             | AppsError::InvalidDeploymentHook => {

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -26,18 +26,19 @@
 
 pub use self::companion::BootstrappingContainer;
 pub use self::companion::DeploymentStrategy;
+pub use self::companion::Routing;
 pub use self::companion::StorageStrategy;
 use self::companion::{Companion, CompanionType, Companions};
 pub use self::container::ContainerConfig;
 pub use self::runtime::Runtime;
 use crate::models::AppName;
 use crate::models::ServiceConfig;
-pub(self) use app_selector::AppSelector;
+use app_selector::AppSelector;
 use clap::Parser;
 use figment::providers::{Env, Format, Toml};
 use figment::value::{Dict, Map, Tag, Value};
 use figment::{Metadata, Profile};
-pub(self) use secret::Secret;
+use secret::Secret;
 use secstr::SecUtf8;
 use std::collections::BTreeMap;
 use std::convert::From;

--- a/api/src/infrastructure/mod.rs
+++ b/api/src/infrastructure/mod.rs
@@ -31,7 +31,7 @@ pub use dummy_infrastructure::DummyInfrastructure as Dummy;
 pub use infrastructure::Infrastructure;
 pub use kubernetes::KubernetesInfrastructure as Kubernetes;
 use serde_json::{map::Map, Value};
-pub use traefik::{TraefikIngressRoute, TraefikRouterRule};
+pub use traefik::{TraefikIngressRoute, TraefikMiddleware, TraefikRouterRule};
 
 mod docker;
 #[cfg(test)]

--- a/api/src/models/mod.rs
+++ b/api/src/models/mod.rs
@@ -30,7 +30,7 @@ pub use image::Image;
 pub use logs_chunks::LogChunk;
 pub use request_info::RequestInfo;
 pub use service::{ContainerType, ServiceBuilder, ServiceBuilderError};
-pub use service_config::{Environment, EnvironmentVariable, Router, ServiceConfig};
+pub use service_config::{Environment, EnvironmentVariable, ServiceConfig};
 pub use web_host_meta::WebHostMeta;
 
 mod app_name;

--- a/api/src/models/service_config/mod.rs
+++ b/api/src/models/service_config/mod.rs
@@ -23,14 +23,13 @@
  * THE SOFTWARE.
  * =========================LICENSE_END==================================
  */
+use crate::config::Routing;
 use crate::models::service::ContainerType;
 use crate::models::Image;
 pub use environment::{Environment, EnvironmentVariable};
 use secstr::SecUtf8;
 use serde::Deserialize;
-use serde_value::Value;
 use std::collections::BTreeMap;
-use std::hash::Hash;
 use std::path::PathBuf;
 
 mod environment;
@@ -51,9 +50,7 @@ pub struct ServiceConfig {
     #[serde(skip)]
     port: u16,
     #[serde(skip)]
-    router: Option<Router>,
-    #[serde(skip)]
-    middlewares: Option<BTreeMap<String, Value>>,
+    routing: Option<Routing>,
 }
 
 impl ServiceConfig {
@@ -66,8 +63,7 @@ impl ServiceConfig {
             labels: None,
             container_type: ContainerType::Instance,
             port: 80,
-            router: None,
-            middlewares: None,
+            routing: None,
         }
     }
 
@@ -145,26 +141,12 @@ impl ServiceConfig {
         self.port
     }
 
-    pub fn set_router(&mut self, router: Router) {
-        self.router = Some(router);
+    pub fn set_routing(&mut self, routing: Routing) {
+        self.routing = Some(routing);
     }
 
-    pub fn router<'a, 'b: 'a>(&'b self) -> Option<&'a Router> {
-        match &self.router {
-            None => None,
-            Some(router) => Some(router),
-        }
-    }
-
-    pub fn set_middlewares(&mut self, middlewares: BTreeMap<String, Value>) {
-        self.middlewares = Some(middlewares);
-    }
-
-    pub fn middlewares<'a, 'b: 'a>(&'b self) -> Option<&BTreeMap<String, Value>> {
-        match &self.middlewares {
-            None => None,
-            Some(middlewares) => Some(middlewares),
-        }
+    pub fn routing<'a, 'b: 'a>(&'b self) -> Option<&'a Routing> {
+        self.routing.as_ref()
     }
 
     /// Copy labels, envs and files from other into self.
@@ -192,31 +174,6 @@ impl ServiceConfig {
         let mut labels = other.labels.as_ref().cloned().unwrap_or_default();
         labels.extend(self.labels.as_ref().cloned().unwrap_or_default());
         self.labels = Some(labels);
-    }
-}
-
-/// Helper that configures the service routing for Traefik (see
-/// [here](https://docs.traefik.io/routing/routers/)).
-#[derive(Clone, Debug, Hash, Deserialize, Eq, PartialEq)]
-pub struct Router {
-    rule: String,
-    priority: Option<i32>,
-}
-
-impl Router {
-    #[cfg(test)]
-    pub fn new(rule: String, priority: Option<i32>) -> Self {
-        Router { rule, priority }
-    }
-
-    pub fn rule(&self) -> &String {
-        &self.rule
-    }
-
-    pub fn with_rule(&self, rule: String) -> Self {
-        let mut r = self.clone();
-        r.rule = rule;
-        r
     }
 }
 

--- a/docs/companions.md
+++ b/docs/companions.md
@@ -45,6 +45,44 @@ Furthermore, you can provide labels through handlebars templating:
 "com.github.prevant" = "bar-{{application.name}}"
 ```
 
+#### Routing
+
+If you need to customize the routing behaviour of companions you can adjust it
+for companions. For example, [Adminer](https://hub.docker.com/_/adminer) needs
+some adjustments to accept logins running behind a reverse proxy (which is
+Traefik).
+
+```toml
+[companions.adminer]
+type = 'application'
+image = 'adminer:4.8.1'
+
+[companions.adminer.routing.additionalMiddlewares]
+headers = { 'customRequestHeaders' = { 'X-Forwarded-Prefix' =  '/{{application.name}}/adminer' } }
+```
+
+In addition, you can overwrite the whole routing of the companion. For example,
+if you want to make the Adminer available under
+`/{{application.name}}/adminer/sub-path/` you can provide following
+configuration.
+
+```toml
+[companions.adminer]
+type = 'application'
+image = 'adminer:4.8.1'
+
+[companions.adminer.routing]
+rule = 'PathPrefix(`/{{application.name}}/adminer/sub-path`)'
+
+[companions.adminer.routing.additionalMiddlewares]
+headers = { 'customRequestHeaders' = { 'X-Forwarded-Prefix' =  '/{{application.name}}/adminer/sub-path' } }
+stripPrefix = { 'prefixes' = [ '/{{application.name}}/adminer/sub-path' ] }
+```
+
+Please, note that PREvant in the latter case does not set the [StripPrefix
+Middleware](https://doc.traefik.io/traefik/middlewares/http/stripprefix/) and
+it needs to be recreated.
+
 #### Template Variables
 
 The list of available handlebars variables:


### PR DESCRIPTION
This commit enables that the routing of companions can be adjusted. For example the routing configuration of Adminer needs additional middleware configs (X-Forwarded-Prefix) to be usable behind an URL with sub path.