### PR TITLE
Companion Configuration section Update companions.md

### DIFF
--- a/docs/companions.md
+++ b/docs/companions.md
@@ -1,7 +1,7 @@
 # Companion Configuration
 
 For better understanding, take a look at [Companions
-section](https://github.com/aixigo/PREvant?tab=readme-ov-file#companions) to
+section](../README.md#companions) to
 grasp what a companion is. The following sections provide example configurations
 for these use cases.
 

--- a/docs/companions.md
+++ b/docs/companions.md
@@ -1,8 +1,9 @@
 # Companion Configuration
 
-Have a look at the [basic terminology](../README.md) to understand what a
-companion is. For these use cases the following sections provide example
-configurations.
+For better understanding, take a look at [Companions
+section](https://github.com/aixigo/PREvant?tab=readme-ov-file#companions) to
+grasp what a companion is. The following sections provide example configurations
+for these use cases.
 
 A simple, but limited configuration of companions can be done via the
 `config.toml` file for [application companions](#application-wide) and [service


### PR DESCRIPTION
Needed better paraphrasing and the link was referring to basic terminologies section, but I wanted it to directly refer to the Companions section.