### PR TITLE
Improve App Name Handling

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arrayvec"
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "shlex",
 ]
@@ -609,9 +609,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -832,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -844,9 +844,9 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "figment"
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "headers"
@@ -1411,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
  "hyper 1.5.0",
  "hyper-util",
@@ -1621,24 +1621,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
 ]
 
 [[package]]
-name = "idna"
-version = "1.0.2"
+name = "idna_adapter"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
- "smallvec",
- "utf8_iter",
 ]
 
 [[package]]
@@ -1659,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -1766,7 +1765,7 @@ dependencies = [
  "email_address",
  "fancy-regex",
  "fraction",
- "idna 1.0.2",
+ "idna",
  "itoa",
  "num-cmp",
  "once_cell",
@@ -1897,9 +1896,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libredox"
@@ -2695,7 +2694,7 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -2710,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2898,9 +2897,9 @@ checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -3073,9 +3072,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3083,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
@@ -3102,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3339,9 +3338,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3403,9 +3402,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
@@ -3414,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3433,18 +3432,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3522,9 +3521,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3810,12 +3809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,12 +3843,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]

--- a/api/src/apps/mod.rs
+++ b/api/src/apps/mod.rs
@@ -728,7 +728,7 @@ mod tests {
         let apps = AppsService::new(config, infrastructure)?;
 
         apps.create_or_update(
-            &AppName::from_str("master-1.x").unwrap(),
+            &AppName::from_str("master-1x").unwrap(),
             &AppStatusChangeId::new(),
             None,
             &vec![sc!("mariadb")],
@@ -738,7 +738,7 @@ mod tests {
 
         let configs = apps
             .infrastructure
-            .get_configs_of_app(&AppName::from_str("master-1.x").unwrap())
+            .get_configs_of_app(&AppName::from_str("master-1x").unwrap())
             .await?;
         assert_eq!(configs.len(), 1);
 

--- a/api/src/apps/routes/logs.rs
+++ b/api/src/apps/routes/logs.rs
@@ -31,11 +31,11 @@ pub(super) async fn logs<'r>(
         Some(since) => match DateTime::parse_from_rfc3339(&since) {
             Ok(since) => Some(since),
             Err(err) => {
-                return Err(
-                    HttpApiProblem::with_title(http_api_problem::StatusCode::BAD_REQUEST)
-                        .detail(format!("{}", err))
-                        .into(),
-                );
+                return Err(HttpApiProblem::with_title_and_type(
+                    http_api_problem::StatusCode::BAD_REQUEST,
+                )
+                .detail(format!("{}", err))
+                .into());
             }
         },
     };
@@ -70,11 +70,11 @@ pub(super) async fn stream_logs<'r>(
         Some(since) => match DateTime::parse_from_rfc3339(since) {
             Ok(since) => Some(since),
             Err(err) => {
-                return Err(
-                    HttpApiProblem::with_title(http_api_problem::StatusCode::BAD_REQUEST)
-                        .detail(format!("{}", err))
-                        .into(),
-                );
+                return Err(HttpApiProblem::with_title_and_type(
+                    http_api_problem::StatusCode::BAD_REQUEST,
+                )
+                .detail(format!("{}", err))
+                .into());
             }
         },
     };
@@ -108,8 +108,9 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for LogsResponse<'r> {
         use std::io::Cursor;
         let log_chunk = match self.log_chunk {
             None => {
-                let payload = HttpApiProblem::with_title(http_api_problem::StatusCode::NOT_FOUND)
-                    .json_bytes();
+                let payload =
+                    HttpApiProblem::with_title_and_type(http_api_problem::StatusCode::NOT_FOUND)
+                        .json_bytes();
                 return Response::build()
                     .status(Status::NotFound)
                     .raw_header("Content-type", "application/problem+json")

--- a/api/src/apps/routes/mod.rs
+++ b/api/src/apps/routes/mod.rs
@@ -88,7 +88,7 @@ async fn status_change(
 
     match spawn_with_options(options, future).await? {
         Poll::Pending => Ok(AsyncCompletion::Pending(app_name, status_id)),
-        Poll::Ready(Ok(_)) => Err(HttpApiProblem::with_title(StatusCode::NOT_FOUND).into()),
+        Poll::Ready(Ok(_)) => Err(HttpApiProblem::with_title_and_type(StatusCode::NOT_FOUND).into()),
         Poll::Ready(Err(err)) => Err(err.into()),
     }
 }
@@ -119,7 +119,7 @@ pub async fn delete_app_sync(
 ) -> HttpResult<Json<Vec<Service>>> {
     match delete_app(app_name, apps, RunOptions::Sync).await? {
         AsyncCompletion::Pending(_, _) => {
-            Err(HttpApiProblem::with_title(StatusCode::INTERNAL_SERVER_ERROR).into())
+            Err(HttpApiProblem::with_title_and_type(StatusCode::INTERNAL_SERVER_ERROR).into())
         }
         AsyncCompletion::Ready(result) => Ok(result),
     }
@@ -217,7 +217,7 @@ where
 }
 
 fn map_join_error(err: tokio::task::JoinError) -> HttpApiError {
-    HttpApiProblem::with_title(StatusCode::INTERNAL_SERVER_ERROR)
+    HttpApiProblem::with_title_and_type(StatusCode::INTERNAL_SERVER_ERROR)
         .detail(format!("{}", err))
         .into()
 }

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -601,7 +601,7 @@ mod tests {
         let mut service_config = service_config!("mariadb");
         config.add_secrets_to(
             &mut service_config,
-            &AppName::from_str("master-1.x").unwrap(),
+            &AppName::from_str("master-1x").unwrap(),
         );
 
         let secret_file_content = service_config
@@ -648,7 +648,7 @@ mod tests {
         let mut service_config = service_config!("mariadb");
         config.add_secrets_to(
             &mut service_config,
-            &AppName::from_str("master-1.x").unwrap(),
+            &AppName::from_str("master-1x").unwrap(),
         );
 
         assert_eq!(service_config.files(), None);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,9 +11,7 @@
 </head>
 <body>
 
-<nav id="nav"></nav>
-
-<div id="app"></div>
+<div id="main"></div>
 <script type="module" src="/src/main.js"></script>
 
 </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,30 +13,52 @@
             "@fortawesome/fontawesome-svg-core": "^1.2.36",
             "@fortawesome/free-solid-svg-icons": "^5.15.4",
             "@fortawesome/vue-fontawesome": "^3.0.3",
-            "@vue/compat": "^3.4.27",
+            "@vue/compat": "^3.5.11",
             "bootstrap-material-design": "^4.1.3",
-            "core-js": "^3.37.1",
+            "core-js": "^3.38.1",
             "http-link-header": "^1.1.3",
             "jquery": "^3.7.1",
             "moment": "^2.30.1",
             "popper.js": "^1.16.1",
-            "swagger-ui": "^4.19.0",
-            "vue": "^3.4.27",
-            "vue-router": "^4.3.2",
+            "swagger-ui": "^4.19.1",
+            "vue": "^3.5.12",
+            "vue-router": "^4.4.5",
             "vue-virtual-scroller": "^2.0.0-beta.8",
             "vuex": "^4.1.0"
          },
          "devDependencies": {
             "@rollup/plugin-inject": "^5.0.5",
-            "@vitejs/plugin-vue": "^5.0.4",
-            "sass": "1.77.1",
-            "vite": "^5.2.11"
+            "@vitejs/plugin-vue": "^5.1.4",
+            "sass": "1.79.5",
+            "vite": "^5.4.9"
+         }
+      },
+      "node_modules/@babel/helper-string-parser": {
+         "version": "7.25.9",
+         "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+         "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
+      "node_modules/@babel/helper-validator-identifier": {
+         "version": "7.25.9",
+         "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+         "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=6.9.0"
          }
       },
       "node_modules/@babel/parser": {
-         "version": "7.24.5",
-         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
-         "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
+         "version": "7.26.2",
+         "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+         "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+         "license": "MIT",
+         "dependencies": {
+            "@babel/types": "^7.26.0"
+         },
          "bin": {
             "parser": "bin/babel-parser.js"
          },
@@ -72,19 +94,33 @@
          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
       },
+      "node_modules/@babel/types": {
+         "version": "7.26.0",
+         "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+         "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+         "license": "MIT",
+         "dependencies": {
+            "@babel/helper-string-parser": "^7.25.9",
+            "@babel/helper-validator-identifier": "^7.25.9"
+         },
+         "engines": {
+            "node": ">=6.9.0"
+         }
+      },
       "node_modules/@braintree/sanitize-url": {
          "version": "6.0.2",
          "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
          "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
       },
       "node_modules/@esbuild/aix-ppc64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-         "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+         "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
          "cpu": [
             "ppc64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "aix"
@@ -94,13 +130,14 @@
          }
       },
       "node_modules/@esbuild/android-arm": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-         "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+         "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
          "cpu": [
             "arm"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "android"
@@ -110,13 +147,14 @@
          }
       },
       "node_modules/@esbuild/android-arm64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-         "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+         "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "android"
@@ -126,13 +164,14 @@
          }
       },
       "node_modules/@esbuild/android-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-         "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+         "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "android"
@@ -142,13 +181,14 @@
          }
       },
       "node_modules/@esbuild/darwin-arm64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-         "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+         "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "darwin"
@@ -158,13 +198,14 @@
          }
       },
       "node_modules/@esbuild/darwin-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-         "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+         "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "darwin"
@@ -174,13 +215,14 @@
          }
       },
       "node_modules/@esbuild/freebsd-arm64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-         "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+         "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "freebsd"
@@ -190,13 +232,14 @@
          }
       },
       "node_modules/@esbuild/freebsd-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-         "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+         "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "freebsd"
@@ -206,13 +249,14 @@
          }
       },
       "node_modules/@esbuild/linux-arm": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-         "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+         "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
          "cpu": [
             "arm"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -222,13 +266,14 @@
          }
       },
       "node_modules/@esbuild/linux-arm64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-         "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+         "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -238,13 +283,14 @@
          }
       },
       "node_modules/@esbuild/linux-ia32": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-         "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+         "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
          "cpu": [
             "ia32"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -254,13 +300,14 @@
          }
       },
       "node_modules/@esbuild/linux-loong64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-         "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+         "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
          "cpu": [
             "loong64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -270,13 +317,14 @@
          }
       },
       "node_modules/@esbuild/linux-mips64el": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-         "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+         "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
          "cpu": [
             "mips64el"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -286,13 +334,14 @@
          }
       },
       "node_modules/@esbuild/linux-ppc64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-         "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+         "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
          "cpu": [
             "ppc64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -302,13 +351,14 @@
          }
       },
       "node_modules/@esbuild/linux-riscv64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-         "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+         "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
          "cpu": [
             "riscv64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -318,13 +368,14 @@
          }
       },
       "node_modules/@esbuild/linux-s390x": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-         "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+         "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
          "cpu": [
             "s390x"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -334,13 +385,14 @@
          }
       },
       "node_modules/@esbuild/linux-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-         "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+         "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
@@ -350,13 +402,14 @@
          }
       },
       "node_modules/@esbuild/netbsd-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-         "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+         "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "netbsd"
@@ -366,13 +419,14 @@
          }
       },
       "node_modules/@esbuild/openbsd-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-         "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+         "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "openbsd"
@@ -382,13 +436,14 @@
          }
       },
       "node_modules/@esbuild/sunos-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-         "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+         "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "sunos"
@@ -398,13 +453,14 @@
          }
       },
       "node_modules/@esbuild/win32-arm64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-         "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+         "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
@@ -414,13 +470,14 @@
          }
       },
       "node_modules/@esbuild/win32-ia32": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-         "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+         "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
          "cpu": [
             "ia32"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
@@ -430,13 +487,14 @@
          }
       },
       "node_modules/@esbuild/win32-x64": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-         "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+         "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
@@ -497,9 +555,332 @@
          }
       },
       "node_modules/@jridgewell/sourcemap-codec": {
-         "version": "1.4.15",
-         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-         "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+         "version": "1.5.0",
+         "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+         "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+         "license": "MIT"
+      },
+      "node_modules/@parcel/watcher": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+         "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+         "dev": true,
+         "hasInstallScript": true,
+         "license": "MIT",
+         "dependencies": {
+            "detect-libc": "^1.0.3",
+            "is-glob": "^4.0.3",
+            "micromatch": "^4.0.5",
+            "node-addon-api": "^7.0.0"
+         },
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         },
+         "optionalDependencies": {
+            "@parcel/watcher-android-arm64": "2.5.0",
+            "@parcel/watcher-darwin-arm64": "2.5.0",
+            "@parcel/watcher-darwin-x64": "2.5.0",
+            "@parcel/watcher-freebsd-x64": "2.5.0",
+            "@parcel/watcher-linux-arm-glibc": "2.5.0",
+            "@parcel/watcher-linux-arm-musl": "2.5.0",
+            "@parcel/watcher-linux-arm64-glibc": "2.5.0",
+            "@parcel/watcher-linux-arm64-musl": "2.5.0",
+            "@parcel/watcher-linux-x64-glibc": "2.5.0",
+            "@parcel/watcher-linux-x64-musl": "2.5.0",
+            "@parcel/watcher-win32-arm64": "2.5.0",
+            "@parcel/watcher-win32-ia32": "2.5.0",
+            "@parcel/watcher-win32-x64": "2.5.0"
+         }
+      },
+      "node_modules/@parcel/watcher-android-arm64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+         "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "android"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-darwin-arm64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+         "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-darwin-x64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+         "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-freebsd-x64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+         "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "freebsd"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-arm-glibc": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+         "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+         "cpu": [
+            "arm"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-arm-musl": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+         "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+         "cpu": [
+            "arm"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-arm64-glibc": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+         "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-arm64-musl": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+         "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-x64-glibc": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+         "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-linux-x64-musl": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+         "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-win32-arm64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+         "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-win32-ia32": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+         "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+         "cpu": [
+            "ia32"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher-win32-x64": {
+         "version": "2.5.0",
+         "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
+         "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ],
+         "engines": {
+            "node": ">= 10.0.0"
+         },
+         "funding": {
+            "type": "opencollective",
+            "url": "https://opencollective.com/parcel"
+         }
+      },
+      "node_modules/@parcel/watcher/node_modules/detect-libc": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+         "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "bin": {
+            "detect-libc": "bin/detect-libc.js"
+         },
+         "engines": {
+            "node": ">=0.10"
+         }
       },
       "node_modules/@rollup/plugin-inject": {
          "version": "5.0.5",
@@ -545,482 +926,543 @@
             }
          }
       },
-      "node_modules/@rollup/plugin-inject/node_modules/magic-string": {
-         "version": "0.30.10",
-         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-         "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-         "dev": true,
-         "dependencies": {
-            "@jridgewell/sourcemap-codec": "^1.4.15"
-         }
-      },
       "node_modules/@rollup/rollup-android-arm-eabi": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.17.2.tgz",
-         "integrity": "sha512-NM0jFxY8bB8QLkoKxIQeObCaDlJKewVlIEkuyYKm5An1tdVZ966w2+MPQ2l8LBZLjR+SgyV+nRkTIunzOYBMLQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.25.0.tgz",
+         "integrity": "sha512-CC/ZqFZwlAIbU1wUPisHyV/XRc5RydFrNLtgl3dGYskdwPZdt4HERtKm50a/+DtTlKeCq9IXFEWR+P6blwjqBA==",
          "cpu": [
             "arm"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "android"
          ]
       },
       "node_modules/@rollup/rollup-android-arm64": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.17.2.tgz",
-         "integrity": "sha512-yeX/Usk7daNIVwkq2uGoq2BYJKZY1JfyLTaHO/jaiSwi/lsf8fTFoQW/n6IdAsx5tx+iotu2zCJwz8MxI6D/Bw==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.25.0.tgz",
+         "integrity": "sha512-/Y76tmLGUJqVBXXCfVS8Q8FJqYGhgH4wl4qTA24E9v/IJM0XvJCGQVSW1QZ4J+VURO9h8YCa28sTFacZXwK7Rg==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "android"
          ]
       },
       "node_modules/@rollup/rollup-darwin-arm64": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.17.2.tgz",
-         "integrity": "sha512-kcMLpE6uCwls023+kknm71ug7MZOrtXo+y5p/tsg6jltpDtgQY1Eq5sGfHcQfb+lfuKwhBmEURDga9N0ol4YPw==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.25.0.tgz",
+         "integrity": "sha512-YVT6L3UrKTlC0FpCZd0MGA7NVdp7YNaEqkENbWQ7AOVOqd/7VzyHpgIpc1mIaxRAo1ZsJRH45fq8j4N63I/vvg==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "darwin"
          ]
       },
       "node_modules/@rollup/rollup-darwin-x64": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.17.2.tgz",
-         "integrity": "sha512-AtKwD0VEx0zWkL0ZjixEkp5tbNLzX+FCqGG1SvOu993HnSz4qDI6S4kGzubrEJAljpVkhRSlg5bzpV//E6ysTQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.25.0.tgz",
+         "integrity": "sha512-ZRL+gexs3+ZmmWmGKEU43Bdn67kWnMeWXLFhcVv5Un8FQcx38yulHBA7XR2+KQdYIOtD0yZDWBCudmfj6lQJoA==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "darwin"
          ]
       },
+      "node_modules/@rollup/rollup-freebsd-arm64": {
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.25.0.tgz",
+         "integrity": "sha512-xpEIXhiP27EAylEpreCozozsxWQ2TJbOLSivGfXhU4G1TBVEYtUPi2pOZBnvGXHyOdLAUUhPnJzH3ah5cqF01g==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "freebsd"
+         ]
+      },
+      "node_modules/@rollup/rollup-freebsd-x64": {
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.25.0.tgz",
+         "integrity": "sha512-sC5FsmZGlJv5dOcURrsnIK7ngc3Kirnx3as2XU9uER+zjfyqIjdcMVgzy4cOawhsssqzoAX19qmxgJ8a14Qrqw==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "freebsd"
+         ]
+      },
       "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.17.2.tgz",
-         "integrity": "sha512-3reX2fUHqN7sffBNqmEyMQVj/CKhIHZd4y631duy0hZqI8Qoqf6lTtmAKvJFYa6bhU95B1D0WgzHkmTg33In0A==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.25.0.tgz",
+         "integrity": "sha512-uD/dbLSs1BEPzg564TpRAQ/YvTnCds2XxyOndAO8nJhaQcqQGFgv/DAVko/ZHap3boCvxnzYMa3mTkV/B/3SWA==",
          "cpu": [
             "arm"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.17.2.tgz",
-         "integrity": "sha512-uSqpsp91mheRgw96xtyAGP9FW5ChctTFEoXP0r5FAzj/3ZRv3Uxjtc7taRQSaQM/q85KEKjKsZuiZM3GyUivRg==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.25.0.tgz",
+         "integrity": "sha512-ZVt/XkrDlQWegDWrwyC3l0OfAF7yeJUF4fq5RMS07YM72BlSfn2fQQ6lPyBNjt+YbczMguPiJoCfaQC2dnflpQ==",
          "cpu": [
             "arm"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-arm64-gnu": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.17.2.tgz",
-         "integrity": "sha512-EMMPHkiCRtE8Wdk3Qhtciq6BndLtstqZIroHiiGzB3C5LDJmIZcSzVtLRbwuXuUft1Cnv+9fxuDtDxz3k3EW2A==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.25.0.tgz",
+         "integrity": "sha512-qboZ+T0gHAW2kkSDPHxu7quaFaaBlynODXpBVnPxUgvWYaE84xgCKAPEYE+fSMd3Zv5PyFZR+L0tCdYCMAtG0A==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-arm64-musl": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.17.2.tgz",
-         "integrity": "sha512-NMPylUUZ1i0z/xJUIx6VUhISZDRT+uTWpBcjdv0/zkp7b/bQDF+NfnfdzuTiB1G6HTodgoFa93hp0O1xl+/UbA==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.25.0.tgz",
+         "integrity": "sha512-ndWTSEmAaKr88dBuogGH2NZaxe7u2rDoArsejNslugHZ+r44NfWiwjzizVS1nUOHo+n1Z6qV3X60rqE/HlISgw==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.17.2.tgz",
-         "integrity": "sha512-T19My13y8uYXPw/L/k0JYaX1fJKFT/PWdXiHr8mTbXWxjVF1t+8Xl31DgBBvEKclw+1b00Chg0hxE2O7bTG7GQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.25.0.tgz",
+         "integrity": "sha512-BVSQvVa2v5hKwJSy6X7W1fjDex6yZnNKy3Kx1JGimccHft6HV0THTwNtC2zawtNXKUu+S5CjXslilYdKBAadzA==",
          "cpu": [
             "ppc64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.17.2.tgz",
-         "integrity": "sha512-BOaNfthf3X3fOWAB+IJ9kxTgPmMqPPH5f5k2DcCsRrBIbWnaJCgX2ll77dV1TdSy9SaXTR5iDXRL8n7AnoP5cg==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.25.0.tgz",
+         "integrity": "sha512-G4hTREQrIdeV0PE2JruzI+vXdRnaK1pg64hemHq2v5fhv8C7WjVaeXc9P5i4Q5UC06d/L+zA0mszYIKl+wY8oA==",
          "cpu": [
             "riscv64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-s390x-gnu": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.17.2.tgz",
-         "integrity": "sha512-W0UP/x7bnn3xN2eYMql2T/+wpASLE5SjObXILTMPUBDB/Fg/FxC+gX4nvCfPBCbNhz51C+HcqQp2qQ4u25ok6g==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.25.0.tgz",
+         "integrity": "sha512-9T/w0kQ+upxdkFL9zPVB6zy9vWW1deA3g8IauJxojN4bnz5FwSsUAD034KpXIVX5j5p/rn6XqumBMxfRkcHapQ==",
          "cpu": [
             "s390x"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-x64-gnu": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.17.2.tgz",
-         "integrity": "sha512-Hy7pLwByUOuyaFC6mAr7m+oMC+V7qyifzs/nW2OJfC8H4hbCzOX07Ov0VFk/zP3kBsELWNFi7rJtgbKYsav9QQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.25.0.tgz",
+         "integrity": "sha512-ThcnU0EcMDn+J4B9LD++OgBYxZusuA7iemIIiz5yzEcFg04VZFzdFjuwPdlURmYPZw+fgVrFzj4CA64jSTG4Ig==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-linux-x64-musl": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.17.2.tgz",
-         "integrity": "sha512-h1+yTWeYbRdAyJ/jMiVw0l6fOOm/0D1vNLui9iPuqgRGnXA0u21gAqOyB5iHjlM9MMfNOm9RHCQ7zLIzT0x11Q==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.25.0.tgz",
+         "integrity": "sha512-zx71aY2oQxGxAT1JShfhNG79PnjYhMC6voAjzpu/xmMjDnKNf6Nl/xv7YaB/9SIa9jDYf8RBPWEnjcdlhlv1rQ==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "linux"
          ]
       },
       "node_modules/@rollup/rollup-win32-arm64-msvc": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.17.2.tgz",
-         "integrity": "sha512-tmdtXMfKAjy5+IQsVtDiCfqbynAQE/TQRpWdVataHmhMb9DCoJxp9vLcCBjEQWMiUYxO1QprH/HbY9ragCEFLA==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.25.0.tgz",
+         "integrity": "sha512-JT8tcjNocMs4CylWY/CxVLnv8e1lE7ff1fi6kbGocWwxDq9pj30IJ28Peb+Y8yiPNSF28oad42ApJB8oUkwGww==",
          "cpu": [
             "arm64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
          ]
       },
       "node_modules/@rollup/rollup-win32-ia32-msvc": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.17.2.tgz",
-         "integrity": "sha512-7II/QCSTAHuE5vdZaQEwJq2ZACkBpQDOmQsE6D6XUbnBHW8IAhm4eTufL6msLJorzrHDFv3CF8oCA/hSIRuZeQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.25.0.tgz",
+         "integrity": "sha512-dRLjLsO3dNOfSN6tjyVlG+Msm4IiZnGkuZ7G5NmpzwF9oOc582FZG05+UdfTbz5Jd4buK/wMb6UeHFhG18+OEg==",
          "cpu": [
             "ia32"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
          ]
       },
       "node_modules/@rollup/rollup-win32-x64-msvc": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.17.2.tgz",
-         "integrity": "sha512-TGGO7v7qOq4CYmSBVEYpI1Y5xDuCEnbVC5Vth8mOsW0gDSzxNrVERPc790IGHsrT2dQSimgMr9Ub3Y1Jci5/8w==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.25.0.tgz",
+         "integrity": "sha512-/RqrIFtLB926frMhZD0a5oDa4eFIbyNEwLLloMTEjmqfwZWXywwVVOVmwTsuyhC9HKkVEZcOOi+KV4U9wmOdlg==",
          "cpu": [
             "x64"
          ],
          "dev": true,
+         "license": "MIT",
          "optional": true,
          "os": [
             "win32"
          ]
       },
+      "node_modules/@scarf/scarf": {
+         "version": "1.4.0",
+         "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+         "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+         "hasInstallScript": true,
+         "license": "Apache-2.0"
+      },
       "node_modules/@swagger-api/apidom-ast": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.99.2.tgz",
-         "integrity": "sha512-poNlXWAU2XBl192+lo5sC6loB3qGvwK30V1pta6Hs200KeTayVsMMRL4R6wDDYEtsbv7M3vQaFKcRGbYUk/SgA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-f4Y9t1oBlnsvMoLPCykzn5LRrmARiaPzorocQkMFTkYUPb7RKA4zCuWi67hH4iDVsVvkPutgew19XyJiI3OF9Q==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "unraw": "^3.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-core": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.99.2.tgz",
-         "integrity": "sha512-deudG9eCxqgPnZyIcZzpmDxF0cja0hdPFS2hB0Op6aB4TKc9mOP1+1iEIDI3Tlx/nzgIayyAl1bblyhK3yH5fQ==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-4uXIN8cLigD1SZUDhmrEwW+1zbrB6bbD9Hlpo/BF74t/Nh4ZoEOUXv1oR/8QXB9AsIkdO65FdDHyaPzyGbjMiQ==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-ast": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "minim": "~0.23.8",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "short-unique-id": "^5.0.2",
-            "stampit": "^4.3.2"
+            "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-error": {
-         "version": "0.99.0",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-0.99.0.tgz",
-         "integrity": "sha512-ZdFdn+GeIo23X2GKFrfH4Y5KY8yTzVF1l/Mqjs8+nD30LTbYg6f3ITHn429dk8fDT3NT69fG+gGm60FAFaKkeQ==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-ydHNOKTdp9jaeW2yBvdZazXNCVFPbzC2Dy3dtDWU3MwUtSryoefT9OUQFWL7NxzChFRneNhBEcVl4NRocitXeA==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7"
          }
       },
       "node_modules/@swagger-api/apidom-json-pointer": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.99.2.tgz",
-         "integrity": "sha512-bZENmE3H2si1yP38VLUAdhoMWNxkh98+/dCOESaw3R5zXHG04di3ShbYsCG0StkigF+eCfCdaj6XoikQOGSkiA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-Xo0v4Jxp0ZiAm+OOL2PSLyjiw5OAkCMxI0nN9+vOw1/mfXcC+tdb30QQ9WNtF7O9LExjznfFID/NnDEYqBRDwA==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.99.2.tgz",
-         "integrity": "sha512-854ioZ/FB5DNiJcMinD9/a6dj6h/poOsKcb4POhPTzMSM0fHLIQUp//Ufhx7qL6qsepwtLapkgZ3/hAYN7lnBg==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-0i4KKNboHi7F8Nra2WNHDl9aOndyTcfKiBfdzSw3j+H5wYAHldeKg7zppqj5rVfwZL9pB5r7eFYZlowwGtmlLg==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.99.2.tgz",
-         "integrity": "sha512-HF38kCszKYQqhQ6VMEMqd5r7gPGBRpHwPcoYaRJSDeOST/qLLG78xpoCJKQEyL3PQprea0gXKz1LG1uslDHgtQ==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-d1LLJ/9LQaT/4jJudFhy3xhpjdTA3pVwBBUqXGPgW2Fp21auTYJMBM9J91wvVUXMUQiVg95DohkCb6TNUYzqLw==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-json-schema-draft-7": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-json-schema-draft-7": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.99.2.tgz",
-         "integrity": "sha512-vgCRaqDLI/SmTECZeKO47RGFFx6MCpOcbSm60sV0/ZJxeK+TgkNjIRJTyuRQNts44K863CWgY+bwzzn1zhNqUg==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-sNj4pAmxEfFYIqRcP9A7/gjNMaa7nu1pWT6gTMXtYROyo4XrChc3wit8F76WJEFIiEPLrPs2SrnnA5GIHM7EnA==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-ast": "^0.99.2",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.4"
          }
       },
       "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.99.2.tgz",
-         "integrity": "sha512-ayKGsd65a6p/k4s5L2el+vMoMi8kc/bLXVszWszFDET1eZNvhKwEMLylGzKMfnwAFgpj+kJOKn4MZsD6PK6U/A==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-Okwi0ikBSIBhQwMvsoe1+8Ff55cwwp9hu88N/sTDBxI7lyX0xCGAlSrJ9tx4Z/uOn5X+IL9HCRuNlbFt4Bvi2w==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.4"
          }
       },
       "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.99.2.tgz",
-         "integrity": "sha512-Rn2YeQKxj6hSijQAzGRRxMYDRIedqHjE69z9xigVbvm+iDXxLJIwasuzFa7BIMRDZF5eAJkBPHXTiU9cXVsl6w==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-Y5p+iA1k8HR5d5cS1jtoADPKJLVg5czaHrs39UcMoMPhINqgqKGd2sYKtX7DnglcLARXe06pv0Qs9ERwCd5ayQ==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-ns-json-schema-draft-6": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-json-schema-draft-6": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.4"
          }
       },
       "node_modules/@swagger-api/apidom-ns-openapi-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-0.99.2.tgz",
-         "integrity": "sha512-4YlBvMkxSJIWrOQmsHiVuQ2VkbcWgUnOm7uiRq+8d88ur9mKI5XbP5iUvxCASuONmCqlaSU2+qoM1qesy73XPw==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-hVhpXIG5CXSqeLo7+d5VwN8b9X0BM8yMZCEIxVAu5050GlcHC3CeJVpy+2DEBkbvR9tzc2HfPGMpWyQpgnimhQ==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.99.2.tgz",
-         "integrity": "sha512-fcT597Ty3kqTkoBr1jeZ3Lfbu0a+CKd1l2ojY6RBF/5+dWNux+CRZ9qosax2XZbN+nJhSdvGLLvGvuKaV3Ybug==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-zF2tPojJBGmQ/GuX+QJ0BhBWmnC+ET8Zah9utKpYWFFjqG/Wl6YzWpyrEflXpfGFzDFgoo+R+/3QvzScbPssqg==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-ns-json-schema-draft-4": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-json-schema-draft-4": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.99.2.tgz",
-         "integrity": "sha512-ubO8vi1dYpIV2a3IKhTkBCf125udoCeUZIc9wrhOFwwHHIKeInGR5L6yxlNhOQm0/doYCth77vEqcuTBpxaIrw==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-/7o+/Z2LelLcOdDSeY8O467Tjmr4yp0c8T4l13+zoQlaJFCzoeJqUUzP/dyqLPxqSeSMOez7uXnYpii6F8uYcA==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-ast": "^0.99.2",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-ns-workflows-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-0.99.2.tgz",
-         "integrity": "sha512-lm8G7cbCRXukN4UOb/bPszUiSbvN1ymvwQ2PEkyZN+DzJvYfgRuAxXt7xd2EDKJcxeH4igpAnkKoIoBoSOHg+w==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-workflows-1/-/apidom-ns-workflows-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-tem8H3DHvQNxUqbiLmepccjAyFffS41Z90ibugsw17xzCNIIr6kDwlhiSSGkl52C+IBqoUlE6kdV0afPr2WuUA==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "ts-mixer": "^6.0.3"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.99.2.tgz",
-         "integrity": "sha512-7WPbiUJEWggVmxsssFfW/8JGk8Yu4C9ELneh805kMsgl/DOm6hcHxqT5gXXSwamH0ZQlTmSnHl2OZSlG+U5KKQ==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-8yuL2w3G4zdBxyITLHKSFRwpgl8Rp4/bCR2GTznYKr5wYuN9RVSKAp2sGtuWHnynnpspodswu3AI1BVCLKBj1A==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-api-design-systems": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.99.2.tgz",
-         "integrity": "sha512-ezOA1fjBAQPQ5X0DGYnuFyZMBSBCsaT6k9KDRr7B37Do9yj8YKa/lTlg5usXOrcLm4VgcyJGTKhAJi9kfzCKcA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-I+/tRdC6CK0GfjZgOaTfpjtehkFW7i1A1ixFOPtrwKA8v3oZ2eUW7dIjDMMC0yTt67j7enHlGTw6o2rZZGnjpA==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-api-design-systems": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-api-design-systems": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.99.2.tgz",
-         "integrity": "sha512-b1ncaIc4dD0FGqty3iRCDUA/uHdd7nH271C06blQ+S9Id4D/xXxzd84z8LeNIJNLhCcnueuMKgUkGzvXP+raAA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-FX4buMibcnz0rsQKMBUrZM8cS1/s0pi3TV9HAsKPQY1mKssyeUEE/nlp6DBbYM6kNCEdq2ALvnPtZVwEJpxS3A==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.99.2.tgz",
-         "integrity": "sha512-NuwuwdORyZPhEpxwyEgslyGfVnwIuyDvF5TDT0cLCMOIFDqbE/n77c4FAh/nQUARDEXRthiDb5pdMo/+rOxjFg==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-JsPYRsaKCecY8UN2AHuHm6X0WgWfys6ypH8UPYic1n3XUfNPkTSOaUY87Vi04wJmy8pQ1F0wHeESY//Zb37aIA==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-json": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.99.2.tgz",
-         "integrity": "sha512-wy2WF71bLX1wEJkgmPRCEnXicV155KCelPQhCtzAGGo/B3+OuhknovBWXZNStvoJqZ/2A4a5pvYrgHoVoIKchg==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-CTSgLG33GgC3POxLBCzlXyBBUz+EFGe62VICH012RIYDXHDmcr4dPmfHyj85LVJxLh7regQ+SGL4NwqQSxTY3A==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-ast": "^0.99.2",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "tree-sitter": "=0.20.4",
@@ -1029,136 +1471,145 @@
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-0.99.2.tgz",
-         "integrity": "sha512-z+ATszNWaO2JlixM9h4QpTAW2fE5nPCY4IDcScuWbch8gtKBmv61+53nahYb7tc3W/X0mMqhc1LyTCy5QC2L/w==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-YtPu2BansaTpW6MrIRJgZpa9V+MLl/DFqC2tHbGSO+u73PdWndONRgqzAAc5pBWR+u1RNgULrCK6sX7uPiFLVg==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.99.2.tgz",
-         "integrity": "sha512-78PFDsF67tWDjPCGAD9cNHage8p5Vs2+zili1AF2zch3JkJA/KxBt+5va4A8w1fYaUaXi8LnMkM8VvEIAsNaOw==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-zzZdK+xhj+sVh4z3vZrxdBrDitraD1szJPc3sUC0pukuCz3P7R/u+//6+GLE9UVjUakdbQI2cyKyUOIZX51+/g==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.99.2.tgz",
-         "integrity": "sha512-WQmm14C0EH0dcMzvgrGPeLkWKXyFwyunK9rrRt7xRLn8sL1Em0dC31hiVdgypo3DLrz9YW3PStpSQjEedJaWUQ==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-i7HaRnU2kDtvDqM5Yv1sbYZghCeRhiVQEyaIIp59Zhc5SwLS3dSoD/kh0TeuKpaY5Lg0ISIM3SLRDcdaYUsGww==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-0.99.2.tgz",
-         "integrity": "sha512-rEoE54T8KKRxtdxXgvaYba+GX8853mwcw5nzdrrvOy2tNKqsJANPeJcrQmjVYqJX7SU0HuZPK3zBvyqMyKoNsg==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-QbqCTAvthqhZmFZKf9HBYnVt4kV7konYnauylVFIaE5KAzmZkcb30FtkAwmZfnyW3AURMzZcLfOgJRGHOjYSqA==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.99.2.tgz",
-         "integrity": "sha512-l7ve45cfAj+imE8flypjdo49zpfp0m29stpOO/q2fCD5/46wT3Z4Ve3aKhil8/TRFEX26VOKoYVNjpeUWzUMaw==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-ajVOqs8lNta7uXkFtU5k1zDJTjwV6Ki3uS+JwBvjuMHsF/i/WIZOmgI4g1Z3yQ1c0QI4dHJskq4WDyp2qW64aw==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.99.2.tgz",
-         "integrity": "sha512-1ab06o/M6MAJ0Js4C1bifpj/R0T0mw26Qk4dR7qKzel9dDuEkIRMQF7JHnf2pojZE+aR59Eb4iAMKmxzokHZdA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-ljYmbBFWjIcfN+MJr7JFh6NA/fgyu5gXDI6KUrg/sbWTKdUYP4iNLJPw8VLPBXHnExevjZCt1Ni74mmL4ZfyBg==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-workflows-json-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-0.99.2.tgz",
-         "integrity": "sha512-VsFVmwTX/OfsXyBmIEp5Y+adqBF4Cj/cM/55KPM3mIEmKbc+PK3M08TIotMk1FdCiTafe+I28OZL+WMVujNm1A==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-json-1/-/apidom-parser-adapter-workflows-json-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-vd0H5IYX96AIhOLcU9SJnXDD6OV61i00JDDfJcFnf1K2NCB0D0Otk2V2z9LXqe51s3pZ7d/Dz0biDjYMsMKVww==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-workflows-yaml-1": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-0.99.2.tgz",
-         "integrity": "sha512-yK+48YcllFc8mY711ZJ7uTfPVZmJdujIHbvGLOMxMODmETkZlEjfoTAwNTWvutcuA6cxK70tKUD8vz5572ALQA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-workflows-yaml-1/-/apidom-parser-adapter-workflows-yaml-1-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-lH0AiPetMLRDy38gcB6TmQnaKv6p1ePimnT4xqcVSHEnc/FsjMbyOE3x6DUENau2eeWFduAhofE9zvliW6iJaQ==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.99.2.tgz",
-         "integrity": "sha512-eU6Rd58WzzcOYOajwp9UCURhXVO8SUCrau14W6BuF1DbJCr85FmOigy4yu2b9UWsK44ZPzH8KeyhSYwTkqkgLA==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-mW/W/Q8w4RCw41Y9vggPbsFg+gj0FxKdecVYzZ8TmgyM9oVN6/KZFegUYKlg1HDRAfjceKehE06aLLS5GXEJCA==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-ast": "^0.99.2",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@types/ramda": "~0.29.6",
+            "@swagger-api/apidom-ast": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@swagger-api/apidom-error": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
             "ramda": "~0.30.0",
             "ramda-adjunct": "^5.0.0",
             "tree-sitter": "=0.20.4",
@@ -1167,48 +1618,49 @@
          }
       },
       "node_modules/@swagger-api/apidom-reference": {
-         "version": "0.99.2",
-         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.99.2.tgz",
-         "integrity": "sha512-QwAnCCEUbicPAVPWYOOpSI8rcj2e7TTybn1chGfdogV+NMLprGXBk/A86hO9CaSLMXkCA2rERUznSNSZWC996g==",
+         "version": "1.0.0-alpha.10",
+         "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.0.0-alpha.10.tgz",
+         "integrity": "sha512-aFG6EHC1NOa0IhawTiE8A8TffzmW0PSO5d+lpzvcJ0w7KbrYG6SFQF2L6lZppqGaIGWbmV0Mq3LDU9mgSVEqqQ==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.20.7",
-            "@swagger-api/apidom-core": "^0.99.2",
-            "@types/ramda": "~0.29.6",
-            "axios": "^1.4.0",
+            "@swagger-api/apidom-core": "^1.0.0-alpha.10",
+            "@types/ramda": "~0.30.0",
+            "axios": "^1.7.4",
             "minimatch": "^7.4.3",
             "process": "^0.11.10",
             "ramda": "~0.30.0",
-            "ramda-adjunct": "^5.0.0",
-            "stampit": "^4.3.2"
+            "ramda-adjunct": "^5.0.0"
          },
          "optionalDependencies": {
-            "@swagger-api/apidom-error": "^0.99.0",
-            "@swagger-api/apidom-json-pointer": "^0.99.2",
-            "@swagger-api/apidom-ns-asyncapi-2": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-2": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-0": "^0.99.2",
-            "@swagger-api/apidom-ns-openapi-3-1": "^0.99.2",
-            "@swagger-api/apidom-ns-workflows-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-json": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-json-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-workflows-json-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^0.99.2",
-            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.99.2"
+            "@swagger-api/apidom-error": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-json-pointer": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-ns-asyncapi-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-ns-openapi-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-ns-openapi-3-0": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-ns-openapi-3-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-ns-workflows-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-json": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-workflows-json-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-workflows-yaml-1": "^1.0.0-alpha.1",
+            "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.0.0-alpha.1"
          }
       },
       "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+         "license": "MIT",
          "dependencies": {
             "balanced-match": "^1.0.0"
          }
@@ -1217,6 +1669,7 @@
          "version": "7.4.6",
          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
          "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+         "license": "ISC",
          "dependencies": {
             "brace-expansion": "^2.0.1"
          },
@@ -1228,10 +1681,11 @@
          }
       },
       "node_modules/@types/estree": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-         "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-         "dev": true
+         "version": "1.0.6",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+         "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/@types/hast": {
          "version": "2.3.4",
@@ -1256,11 +1710,12 @@
          "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
       },
       "node_modules/@types/ramda": {
-         "version": "0.29.12",
-         "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.12.tgz",
-         "integrity": "sha512-sgIEjpJhdQPB52gDF4aphs9nl0xe54CR22DPdWqT8gQHjZYmVApgA0R3/CpMbl0Y8az2TEZrPNL2zy0EvjbkLA==",
+         "version": "0.30.2",
+         "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+         "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+         "license": "MIT",
          "dependencies": {
-            "types-ramda": "^0.29.10"
+            "types-ramda": "^0.30.1"
          }
       },
       "node_modules/@types/react": {
@@ -1283,10 +1738,11 @@
          "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
       },
       "node_modules/@vitejs/plugin-vue": {
-         "version": "5.0.4",
-         "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
-         "integrity": "sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==",
+         "version": "5.1.5",
+         "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.5.tgz",
+         "integrity": "sha512-dlnib73G05CDBAUR/YpuZcQQ47fpjihnnNouAAqN62z+oqSsWJ+kh52GRzIxpkgFG3q11eXK7Di7RMmoCwISZA==",
          "dev": true,
+         "license": "MIT",
          "engines": {
             "node": "^18.0.0 || >=20.0.0"
          },
@@ -1296,120 +1752,124 @@
          }
       },
       "node_modules/@vue/compat": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.4.27.tgz",
-         "integrity": "sha512-H2W93cPe9WXXkHiYEeX7f2Z8/znElm44fxgj8uBhgC6cxvjDUOLIcIJySs+FZvv6JM+Re/SBUnlcr4LJMaQZzw==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.5.12.tgz",
+         "integrity": "sha512-44keSoMGAf9l6DVEKpyCUVZXU4KzGPzqtSoauZX5Jde7odhYHep3dBumurJXX64MIa4ZfPnN1whJOoqUAph4PA==",
+         "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.24.4",
+            "@babel/parser": "^7.25.3",
             "estree-walker": "^2.0.2",
             "source-map-js": "^1.2.0"
          },
          "peerDependencies": {
-            "vue": "3.4.27"
+            "vue": "3.5.12"
          }
       },
       "node_modules/@vue/compiler-core": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-         "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.12.tgz",
+         "integrity": "sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==",
+         "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.24.4",
-            "@vue/shared": "3.4.27",
+            "@babel/parser": "^7.25.3",
+            "@vue/shared": "3.5.12",
             "entities": "^4.5.0",
             "estree-walker": "^2.0.2",
             "source-map-js": "^1.2.0"
          }
       },
       "node_modules/@vue/compiler-dom": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-         "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.12.tgz",
+         "integrity": "sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/compiler-core": "3.4.27",
-            "@vue/shared": "3.4.27"
+            "@vue/compiler-core": "3.5.12",
+            "@vue/shared": "3.5.12"
          }
       },
       "node_modules/@vue/compiler-sfc": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-         "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.12.tgz",
+         "integrity": "sha512-2k973OGo2JuAa5+ZlekuQJtitI5CgLMOwgl94BzMCsKZCX/xiqzJYzapl4opFogKHqwJk34vfsaKpfEhd1k5nw==",
+         "license": "MIT",
          "dependencies": {
-            "@babel/parser": "^7.24.4",
-            "@vue/compiler-core": "3.4.27",
-            "@vue/compiler-dom": "3.4.27",
-            "@vue/compiler-ssr": "3.4.27",
-            "@vue/shared": "3.4.27",
+            "@babel/parser": "^7.25.3",
+            "@vue/compiler-core": "3.5.12",
+            "@vue/compiler-dom": "3.5.12",
+            "@vue/compiler-ssr": "3.5.12",
+            "@vue/shared": "3.5.12",
             "estree-walker": "^2.0.2",
-            "magic-string": "^0.30.10",
-            "postcss": "^8.4.38",
+            "magic-string": "^0.30.11",
+            "postcss": "^8.4.47",
             "source-map-js": "^1.2.0"
          }
       },
-      "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
-         "version": "0.30.10",
-         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-         "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-         "dependencies": {
-            "@jridgewell/sourcemap-codec": "^1.4.15"
-         }
-      },
       "node_modules/@vue/compiler-ssr": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-         "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.12.tgz",
+         "integrity": "sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/compiler-dom": "3.4.27",
-            "@vue/shared": "3.4.27"
+            "@vue/compiler-dom": "3.5.12",
+            "@vue/shared": "3.5.12"
          }
       },
       "node_modules/@vue/devtools-api": {
-         "version": "6.6.1",
-         "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.1.tgz",
-         "integrity": "sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA=="
+         "version": "6.6.4",
+         "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+         "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+         "license": "MIT"
       },
       "node_modules/@vue/reactivity": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-         "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.12.tgz",
+         "integrity": "sha512-UzaN3Da7xnJXdz4Okb/BGbAaomRHc3RdoWqTzlvd9+WBR5m3J39J1fGcHes7U3za0ruYn/iYy/a1euhMEHvTAg==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/shared": "3.4.27"
+            "@vue/shared": "3.5.12"
          }
       },
       "node_modules/@vue/runtime-core": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-         "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.12.tgz",
+         "integrity": "sha512-hrMUYV6tpocr3TL3Ad8DqxOdpDe4zuQY4HPY3X/VRh+L2myQO8MFXPAMarIOSGNu0bFAjh1yBkMPXZBqCk62Uw==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/reactivity": "3.4.27",
-            "@vue/shared": "3.4.27"
+            "@vue/reactivity": "3.5.12",
+            "@vue/shared": "3.5.12"
          }
       },
       "node_modules/@vue/runtime-dom": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-         "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.12.tgz",
+         "integrity": "sha512-q8VFxR9A2MRfBr6/55Q3umyoN7ya836FzRXajPB6/Vvuv0zOPL+qltd9rIMzG/DbRLAIlREmnLsplEF/kotXKA==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/runtime-core": "3.4.27",
-            "@vue/shared": "3.4.27",
+            "@vue/reactivity": "3.5.12",
+            "@vue/runtime-core": "3.5.12",
+            "@vue/shared": "3.5.12",
             "csstype": "^3.1.3"
          }
       },
       "node_modules/@vue/server-renderer": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-         "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.12.tgz",
+         "integrity": "sha512-I3QoeDDeEPZm8yR28JtY+rk880Oqmj43hreIBVTicisFTx/Dl7JpG72g/X7YF8hnQD3IFhkky5i2bPonwrTVPg==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/compiler-ssr": "3.4.27",
-            "@vue/shared": "3.4.27"
+            "@vue/compiler-ssr": "3.5.12",
+            "@vue/shared": "3.5.12"
          },
          "peerDependencies": {
-            "vue": "3.4.27"
+            "vue": "3.5.12"
          }
       },
       "node_modules/@vue/shared": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-         "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
+         "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
+         "license": "MIT"
       },
       "node_modules/@yarnpkg/lockfile": {
          "version": "1.1.0",
@@ -1430,19 +1890,6 @@
             "url": "https://github.com/chalk/ansi-styles?sponsor=1"
          }
       },
-      "node_modules/anymatch": {
-         "version": "3.1.3",
-         "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-         "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-         "dev": true,
-         "dependencies": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-         },
-         "engines": {
-            "node": ">= 8"
-         }
-      },
       "node_modules/apg-lite": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.3.tgz",
@@ -1456,7 +1903,8 @@
       "node_modules/asynckit": {
          "version": "0.4.0",
          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-         "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+         "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+         "license": "MIT"
       },
       "node_modules/at-least-node": {
          "version": "1.0.0",
@@ -1475,9 +1923,10 @@
          }
       },
       "node_modules/axios": {
-         "version": "1.6.8",
-         "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-         "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+         "version": "1.7.7",
+         "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+         "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+         "license": "MIT",
          "dependencies": {
             "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
@@ -1508,22 +1957,11 @@
             }
          ]
       },
-      "node_modules/binary-extensions": {
-         "version": "2.3.0",
-         "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-         "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-         "dev": true,
-         "engines": {
-            "node": ">=8"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/sindresorhus"
-         }
-      },
       "node_modules/bl": {
          "version": "4.1.0",
          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "buffer": "^5.5.0",
@@ -1546,11 +1984,12 @@
          }
       },
       "node_modules/braces": {
-         "version": "3.0.2",
-         "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-         "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+         "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+         "license": "MIT",
          "dependencies": {
-            "fill-range": "^7.0.1"
+            "fill-range": "^7.1.1"
          },
          "engines": {
             "node": ">=8"
@@ -1574,28 +2013,11 @@
                "url": "https://feross.org/support"
             }
          ],
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
-         }
-      },
-      "node_modules/call-bind": {
-         "version": "1.0.7",
-         "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-         "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "set-function-length": "^1.2.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/chalk": {
@@ -1641,33 +2063,26 @@
          }
       },
       "node_modules/chokidar": {
-         "version": "3.6.0",
-         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-         "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+         "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
-            "anymatch": "~3.1.2",
-            "braces": "~3.0.2",
-            "glob-parent": "~5.1.2",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.6.0"
+            "readdirp": "^4.0.1"
          },
          "engines": {
-            "node": ">= 8.10.0"
+            "node": ">= 14.16.0"
          },
          "funding": {
             "url": "https://paulmillr.com/funding/"
-         },
-         "optionalDependencies": {
-            "fsevents": "~2.3.2"
          }
       },
       "node_modules/chownr": {
          "version": "1.1.4",
          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+         "license": "ISC",
          "optional": true
       },
       "node_modules/ci-info": {
@@ -1700,6 +2115,7 @@
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+         "license": "MIT",
          "dependencies": {
             "delayed-stream": "~1.0.0"
          },
@@ -1722,9 +2138,10 @@
          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
       },
       "node_modules/cookie": {
-         "version": "0.6.0",
-         "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-         "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+         "version": "0.7.2",
+         "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+         "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+         "license": "MIT",
          "engines": {
             "node": ">= 0.6"
          }
@@ -1738,10 +2155,11 @@
          }
       },
       "node_modules/core-js": {
-         "version": "3.37.1",
-         "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-         "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
+         "version": "3.39.0",
+         "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+         "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
          "hasInstallScript": true,
+         "license": "MIT",
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/core-js"
@@ -1786,6 +2204,7 @@
          "version": "6.0.0",
          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "mimic-response": "^3.1.0"
@@ -1813,26 +2232,11 @@
             "node": ">=0.10.0"
          }
       },
-      "node_modules/define-data-property": {
-         "version": "1.1.4",
-         "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-         "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-         "dependencies": {
-            "es-define-property": "^1.0.0",
-            "es-errors": "^1.3.0",
-            "gopd": "^1.0.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/delayed-stream": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
          "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+         "license": "MIT",
          "engines": {
             "node": ">=0.4.0"
          }
@@ -1841,6 +2245,7 @@
          "version": "2.0.3",
          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
          "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+         "license": "Apache-2.0",
          "optional": true,
          "engines": {
             "node": ">=8"
@@ -1863,6 +2268,7 @@
          "version": "1.4.4",
          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "once": "^1.4.0"
@@ -1872,6 +2278,7 @@
          "version": "4.5.0",
          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+         "license": "BSD-2-Clause",
          "engines": {
             "node": ">=0.12"
          },
@@ -1879,31 +2286,13 @@
             "url": "https://github.com/fb55/entities?sponsor=1"
          }
       },
-      "node_modules/es-define-property": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-         "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-         "dependencies": {
-            "get-intrinsic": "^1.2.4"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
-      "node_modules/es-errors": {
-         "version": "1.3.0",
-         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/esbuild": {
-         "version": "0.20.2",
-         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-         "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+         "version": "0.21.5",
+         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+         "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
          "dev": true,
          "hasInstallScript": true,
+         "license": "MIT",
          "bin": {
             "esbuild": "bin/esbuild"
          },
@@ -1911,29 +2300,29 @@
             "node": ">=12"
          },
          "optionalDependencies": {
-            "@esbuild/aix-ppc64": "0.20.2",
-            "@esbuild/android-arm": "0.20.2",
-            "@esbuild/android-arm64": "0.20.2",
-            "@esbuild/android-x64": "0.20.2",
-            "@esbuild/darwin-arm64": "0.20.2",
-            "@esbuild/darwin-x64": "0.20.2",
-            "@esbuild/freebsd-arm64": "0.20.2",
-            "@esbuild/freebsd-x64": "0.20.2",
-            "@esbuild/linux-arm": "0.20.2",
-            "@esbuild/linux-arm64": "0.20.2",
-            "@esbuild/linux-ia32": "0.20.2",
-            "@esbuild/linux-loong64": "0.20.2",
-            "@esbuild/linux-mips64el": "0.20.2",
-            "@esbuild/linux-ppc64": "0.20.2",
-            "@esbuild/linux-riscv64": "0.20.2",
-            "@esbuild/linux-s390x": "0.20.2",
-            "@esbuild/linux-x64": "0.20.2",
-            "@esbuild/netbsd-x64": "0.20.2",
-            "@esbuild/openbsd-x64": "0.20.2",
-            "@esbuild/sunos-x64": "0.20.2",
-            "@esbuild/win32-arm64": "0.20.2",
-            "@esbuild/win32-ia32": "0.20.2",
-            "@esbuild/win32-x64": "0.20.2"
+            "@esbuild/aix-ppc64": "0.21.5",
+            "@esbuild/android-arm": "0.21.5",
+            "@esbuild/android-arm64": "0.21.5",
+            "@esbuild/android-x64": "0.21.5",
+            "@esbuild/darwin-arm64": "0.21.5",
+            "@esbuild/darwin-x64": "0.21.5",
+            "@esbuild/freebsd-arm64": "0.21.5",
+            "@esbuild/freebsd-x64": "0.21.5",
+            "@esbuild/linux-arm": "0.21.5",
+            "@esbuild/linux-arm64": "0.21.5",
+            "@esbuild/linux-ia32": "0.21.5",
+            "@esbuild/linux-loong64": "0.21.5",
+            "@esbuild/linux-mips64el": "0.21.5",
+            "@esbuild/linux-ppc64": "0.21.5",
+            "@esbuild/linux-riscv64": "0.21.5",
+            "@esbuild/linux-s390x": "0.21.5",
+            "@esbuild/linux-x64": "0.21.5",
+            "@esbuild/netbsd-x64": "0.21.5",
+            "@esbuild/openbsd-x64": "0.21.5",
+            "@esbuild/sunos-x64": "0.21.5",
+            "@esbuild/win32-arm64": "0.21.5",
+            "@esbuild/win32-ia32": "0.21.5",
+            "@esbuild/win32-x64": "0.21.5"
          }
       },
       "node_modules/estree-walker": {
@@ -1945,6 +2334,7 @@
          "version": "2.0.3",
          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+         "license": "(MIT OR WTFPL)",
          "optional": true,
          "engines": {
             "node": ">=6"
@@ -1968,9 +2358,10 @@
          }
       },
       "node_modules/fill-range": {
-         "version": "7.0.1",
-         "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-         "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+         "version": "7.1.1",
+         "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+         "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+         "license": "MIT",
          "dependencies": {
             "to-regex-range": "^5.0.1"
          },
@@ -1987,15 +2378,16 @@
          }
       },
       "node_modules/follow-redirects": {
-         "version": "1.15.6",
-         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-         "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+         "version": "1.15.9",
+         "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+         "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
          "funding": [
             {
                "type": "individual",
                "url": "https://github.com/sponsors/RubenVerborgh"
             }
          ],
+         "license": "MIT",
          "engines": {
             "node": ">=4.0"
          },
@@ -2006,9 +2398,10 @@
          }
       },
       "node_modules/form-data": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-         "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+         "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+         "license": "MIT",
          "dependencies": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -2030,6 +2423,7 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
          "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/fs-extra": {
@@ -2065,36 +2459,11 @@
             "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
          }
       },
-      "node_modules/function-bind": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/get-intrinsic": {
-         "version": "1.2.4",
-         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-         "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-         "dependencies": {
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "has-proto": "^1.0.1",
-            "has-symbols": "^1.0.3",
-            "hasown": "^2.0.0"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/github-from-package": {
          "version": "0.0.0",
          "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
          "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/glob": {
@@ -2116,29 +2485,6 @@
             "url": "https://github.com/sponsors/isaacs"
          }
       },
-      "node_modules/glob-parent": {
-         "version": "5.1.2",
-         "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-         "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-         "dev": true,
-         "dependencies": {
-            "is-glob": "^4.0.1"
-         },
-         "engines": {
-            "node": ">= 6"
-         }
-      },
-      "node_modules/gopd": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-         "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-         "dependencies": {
-            "get-intrinsic": "^1.1.3"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/graceful-fs": {
          "version": "4.2.11",
          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2150,50 +2496,6 @@
          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
          "engines": {
             "node": ">=8"
-         }
-      },
-      "node_modules/has-property-descriptors": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-         "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-         "dependencies": {
-            "es-define-property": "^1.0.0"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-proto": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-         "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/has-symbols": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-         "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
-      "node_modules/hasown": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-         "dependencies": {
-            "function-bind": "^1.1.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
          }
       },
       "node_modules/hast-util-parse-selector": {
@@ -2287,6 +2589,7 @@
          "version": "1.3.8",
          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+         "license": "ISC",
          "optional": true
       },
       "node_modules/invariant": {
@@ -2317,18 +2620,6 @@
          "funding": {
             "type": "github",
             "url": "https://github.com/sponsors/wooorm"
-         }
-      },
-      "node_modules/is-binary-path": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-         "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-         "dev": true,
-         "dependencies": {
-            "binary-extensions": "^2.0.0"
-         },
-         "engines": {
-            "node": ">=8"
          }
       },
       "node_modules/is-ci": {
@@ -2370,6 +2661,7 @@
          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
          "dev": true,
+         "license": "MIT",
          "engines": {
             "node": ">=0.10.0"
          }
@@ -2379,6 +2671,7 @@
          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
             "is-extglob": "^2.1.1"
          },
@@ -2399,16 +2692,9 @@
          "version": "7.0.0",
          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+         "license": "MIT",
          "engines": {
             "node": ">=0.12.0"
-         }
-      },
-      "node_modules/is-plain-object": {
-         "version": "5.0.0",
-         "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-         "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-         "engines": {
-            "node": ">=0.10.0"
          }
       },
       "node_modules/is-wsl": {
@@ -2506,12 +2792,22 @@
             "url": "https://github.com/sponsors/wooorm"
          }
       },
-      "node_modules/micromatch": {
-         "version": "4.0.5",
-         "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-         "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "node_modules/magic-string": {
+         "version": "0.30.12",
+         "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+         "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+         "license": "MIT",
          "dependencies": {
-            "braces": "^3.0.2",
+            "@jridgewell/sourcemap-codec": "^1.5.0"
+         }
+      },
+      "node_modules/micromatch": {
+         "version": "4.0.8",
+         "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+         "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+         "license": "MIT",
+         "dependencies": {
+            "braces": "^3.0.3",
             "picomatch": "^2.3.1"
          },
          "engines": {
@@ -2522,6 +2818,7 @@
          "version": "1.52.0",
          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+         "license": "MIT",
          "engines": {
             "node": ">= 0.6"
          }
@@ -2530,6 +2827,7 @@
          "version": "2.1.35",
          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+         "license": "MIT",
          "dependencies": {
             "mime-db": "1.52.0"
          },
@@ -2541,6 +2839,7 @@
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+         "license": "MIT",
          "optional": true,
          "engines": {
             "node": ">=10"
@@ -2553,6 +2852,7 @@
          "version": "0.23.8",
          "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
          "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
+         "license": "MIT",
          "dependencies": {
             "lodash": "^4.15.0"
          },
@@ -2588,6 +2888,7 @@
          "version": "0.5.3",
          "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
          "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/moment": {
@@ -2599,9 +2900,10 @@
          }
       },
       "node_modules/nan": {
-         "version": "2.19.0",
-         "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-         "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+         "version": "2.22.0",
+         "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+         "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/nanoid": {
@@ -2614,6 +2916,7 @@
                "url": "https://github.com/sponsors/ai"
             }
          ],
+         "license": "MIT",
          "bin": {
             "nanoid": "bin/nanoid.cjs"
          },
@@ -2625,7 +2928,17 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
          "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+         "license": "MIT",
          "optional": true
+      },
+      "node_modules/neotraverse": {
+         "version": "0.6.18",
+         "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+         "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+         "license": "MIT",
+         "engines": {
+            "node": ">= 10"
+         }
       },
       "node_modules/nice-try": {
          "version": "1.0.5",
@@ -2633,9 +2946,10 @@
          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
       },
       "node_modules/node-abi": {
-         "version": "3.62.0",
-         "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
-         "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
+         "version": "3.71.0",
+         "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.71.0.tgz",
+         "integrity": "sha512-SZ40vRiy/+wRTf21hxkkEjPJZpARzUMVcJoQse2EF8qkUWbbO2z7vd5oA/H6bVH6SZQ5STGcu0KRDS7biNRfxw==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "semver": "^7.3.5"
@@ -2645,9 +2959,10 @@
          }
       },
       "node_modules/node-abi/node_modules/semver": {
-         "version": "7.6.2",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-         "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+         "version": "7.6.3",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+         "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+         "license": "ISC",
          "optional": true,
          "bin": {
             "semver": "bin/semver.js"
@@ -2660,6 +2975,13 @@
          "version": "3.1.1",
          "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
          "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+      },
+      "node_modules/node-addon-api": {
+         "version": "7.1.1",
+         "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+         "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/node-domexception": {
          "version": "1.0.0",
@@ -2695,29 +3017,12 @@
             "url": "https://opencollective.com/node-fetch"
          }
       },
-      "node_modules/normalize-path": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-         "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-         "dev": true,
-         "engines": {
-            "node": ">=0.10.0"
-         }
-      },
       "node_modules/object-assign": {
          "version": "4.1.1",
          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
          "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
          "engines": {
             "node": ">=0.10.0"
-         }
-      },
-      "node_modules/object-inspect": {
-         "version": "1.13.1",
-         "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-         "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/once": {
@@ -2747,6 +3052,18 @@
          "version": "1.5.1",
          "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-1.5.1.tgz",
          "integrity": "sha512-kgRHToVP571U1YzUnaZnWaUIygon2itg5g96kwaFIi8bnpsw4oXYOk7k59Ivn+ley1iQnMENe/1HSovpPVZuXA==",
+         "dependencies": {
+            "apg-lite": "^1.0.3"
+         },
+         "engines": {
+            "node": ">=12.20.0"
+         }
+      },
+      "node_modules/openapi-server-url-templating": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.1.0.tgz",
+         "integrity": "sha512-dtyTFKx2xVcO0W8JKaluXIHC9l/MLjHeflBaWjiWNMCHp/TBs9dEjQDbj/VFlHR4omFOKjjmqm1pW1aCAhmPBg==",
+         "license": "Apache-2.0",
          "dependencies": {
             "apg-lite": "^1.0.3"
          },
@@ -2824,9 +3141,10 @@
          }
       },
       "node_modules/picocolors": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-         "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+         "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+         "license": "ISC"
       },
       "node_modules/picomatch": {
          "version": "2.3.1",
@@ -2850,9 +3168,9 @@
          }
       },
       "node_modules/postcss": {
-         "version": "8.4.38",
-         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-         "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+         "version": "8.4.49",
+         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+         "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
          "funding": [
             {
                "type": "opencollective",
@@ -2867,10 +3185,11 @@
                "url": "https://github.com/sponsors/ai"
             }
          ],
+         "license": "MIT",
          "dependencies": {
             "nanoid": "^3.3.7",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.2.0"
+            "picocolors": "^1.1.1",
+            "source-map-js": "^1.2.1"
          },
          "engines": {
             "node": "^10 || ^12 || >=14"
@@ -2880,6 +3199,7 @@
          "version": "7.1.2",
          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "detect-libc": "^2.0.0",
@@ -2914,6 +3234,7 @@
          "version": "0.11.10",
          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
          "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+         "license": "MIT",
          "engines": {
             "node": ">= 0.6.0"
          }
@@ -2943,30 +3264,18 @@
       "node_modules/proxy-from-env": {
          "version": "1.1.0",
          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-         "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+         "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+         "license": "MIT"
       },
       "node_modules/pump": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-         "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+         "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
-         }
-      },
-      "node_modules/qs": {
-         "version": "6.12.1",
-         "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-         "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
-         "dependencies": {
-            "side-channel": "^1.0.6"
-         },
-         "engines": {
-            "node": ">=0.6"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/querystringify": {
@@ -2975,18 +3284,20 @@
          "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
       },
       "node_modules/ramda": {
-         "version": "0.30.0",
-         "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.0.tgz",
-         "integrity": "sha512-13Y0iMhIQuAm/wNGBL/9HEqIfRGmNmjKnTPlKWfA9f7dnDkr8d45wQ+S7+ZLh/Pq9PdcGxkqKUEA7ySu1QSd9Q==",
+         "version": "0.30.1",
+         "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+         "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+         "license": "MIT",
          "funding": {
             "type": "opencollective",
             "url": "https://opencollective.com/ramda"
          }
       },
       "node_modules/ramda-adjunct": {
-         "version": "5.0.0",
-         "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.0.0.tgz",
-         "integrity": "sha512-iEehjqp/ZGjYZybZByDaDu27c+79SE7rKDcySLdmjAwKWkz6jNhvGgZwzUGaMsij8Llp9+1N1Gy0drpAq8ZSyA==",
+         "version": "5.1.0",
+         "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
+         "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
+         "license": "BSD-3-Clause",
          "engines": {
             "node": ">=0.10.3"
          },
@@ -3022,6 +3333,7 @@
          "version": "1.2.8",
          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+         "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
          "optional": true,
          "dependencies": {
             "deep-extend": "^0.6.0",
@@ -3178,6 +3490,7 @@
          "version": "3.6.2",
          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "inherits": "^2.0.3",
@@ -3189,15 +3502,17 @@
          }
       },
       "node_modules/readdirp": {
-         "version": "3.6.0",
-         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-         "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+         "version": "4.0.2",
+         "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+         "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
          "dev": true,
-         "dependencies": {
-            "picomatch": "^2.2.1"
-         },
+         "license": "MIT",
          "engines": {
-            "node": ">=8.10.0"
+            "node": ">= 14.16.0"
+         },
+         "funding": {
+            "type": "individual",
+            "url": "https://paulmillr.com/funding/"
          }
       },
       "node_modules/redux": {
@@ -3304,12 +3619,13 @@
          }
       },
       "node_modules/rollup": {
-         "version": "4.17.2",
-         "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
-         "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
+         "version": "4.25.0",
+         "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.25.0.tgz",
+         "integrity": "sha512-uVbClXmR6wvx5R1M3Od4utyLUxrmOcEm3pAtMphn73Apq19PDtHpgZoEvqH2YnnaNUuvKmg2DgRd2Sqv+odyqg==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
-            "@types/estree": "1.0.5"
+            "@types/estree": "1.0.6"
          },
          "bin": {
             "rollup": "dist/bin/rollup"
@@ -3319,22 +3635,24 @@
             "npm": ">=8.0.0"
          },
          "optionalDependencies": {
-            "@rollup/rollup-android-arm-eabi": "4.17.2",
-            "@rollup/rollup-android-arm64": "4.17.2",
-            "@rollup/rollup-darwin-arm64": "4.17.2",
-            "@rollup/rollup-darwin-x64": "4.17.2",
-            "@rollup/rollup-linux-arm-gnueabihf": "4.17.2",
-            "@rollup/rollup-linux-arm-musleabihf": "4.17.2",
-            "@rollup/rollup-linux-arm64-gnu": "4.17.2",
-            "@rollup/rollup-linux-arm64-musl": "4.17.2",
-            "@rollup/rollup-linux-powerpc64le-gnu": "4.17.2",
-            "@rollup/rollup-linux-riscv64-gnu": "4.17.2",
-            "@rollup/rollup-linux-s390x-gnu": "4.17.2",
-            "@rollup/rollup-linux-x64-gnu": "4.17.2",
-            "@rollup/rollup-linux-x64-musl": "4.17.2",
-            "@rollup/rollup-win32-arm64-msvc": "4.17.2",
-            "@rollup/rollup-win32-ia32-msvc": "4.17.2",
-            "@rollup/rollup-win32-x64-msvc": "4.17.2",
+            "@rollup/rollup-android-arm-eabi": "4.25.0",
+            "@rollup/rollup-android-arm64": "4.25.0",
+            "@rollup/rollup-darwin-arm64": "4.25.0",
+            "@rollup/rollup-darwin-x64": "4.25.0",
+            "@rollup/rollup-freebsd-arm64": "4.25.0",
+            "@rollup/rollup-freebsd-x64": "4.25.0",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.25.0",
+            "@rollup/rollup-linux-arm-musleabihf": "4.25.0",
+            "@rollup/rollup-linux-arm64-gnu": "4.25.0",
+            "@rollup/rollup-linux-arm64-musl": "4.25.0",
+            "@rollup/rollup-linux-powerpc64le-gnu": "4.25.0",
+            "@rollup/rollup-linux-riscv64-gnu": "4.25.0",
+            "@rollup/rollup-linux-s390x-gnu": "4.25.0",
+            "@rollup/rollup-linux-x64-gnu": "4.25.0",
+            "@rollup/rollup-linux-x64-musl": "4.25.0",
+            "@rollup/rollup-win32-arm64-msvc": "4.25.0",
+            "@rollup/rollup-win32-ia32-msvc": "4.25.0",
+            "@rollup/rollup-win32-x64-msvc": "4.25.0",
             "fsevents": "~2.3.2"
          }
       },
@@ -3358,12 +3676,14 @@
          ]
       },
       "node_modules/sass": {
-         "version": "1.77.1",
-         "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.1.tgz",
-         "integrity": "sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==",
+         "version": "1.79.5",
+         "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.5.tgz",
+         "integrity": "sha512-W1h5kp6bdhqFh2tk3DsI771MoEJjvrSY/2ihJRJS4pjIyfJCw0nTsxqhnrUzaLMOJjFchj8rOvraI/YUVjtx5g==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
-            "chokidar": ">=3.0.0 <4.0.0",
+            "@parcel/watcher": "^2.4.1",
+            "chokidar": "^4.0.0",
             "immutable": "^4.0.0",
             "source-map-js": ">=0.6.2 <2.0.0"
          },
@@ -3416,22 +3736,6 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
-      "node_modules/set-function-length": {
-         "version": "1.2.2",
-         "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-         "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-         "dependencies": {
-            "define-data-property": "^1.1.4",
-            "es-errors": "^1.3.0",
-            "function-bind": "^1.1.2",
-            "get-intrinsic": "^1.2.4",
-            "gopd": "^1.0.1",
-            "has-property-descriptors": "^1.0.2"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         }
-      },
       "node_modules/sha.js": {
          "version": "2.4.11",
          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -3467,26 +3771,10 @@
          "version": "5.2.0",
          "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.2.0.tgz",
          "integrity": "sha512-cMGfwNyfDZ/nzJ2k2M+ClthBIh//GlZl1JEf47Uoa9XR11bz8Pa2T2wQO4bVrRdH48LrIDWJahQziKo3MjhsWg==",
+         "license": "Apache-2.0",
          "bin": {
             "short-unique-id": "bin/short-unique-id",
             "suid": "bin/short-unique-id"
-         }
-      },
-      "node_modules/side-channel": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-         "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-         "dependencies": {
-            "call-bind": "^1.0.7",
-            "es-errors": "^1.3.0",
-            "get-intrinsic": "^1.2.4",
-            "object-inspect": "^1.13.1"
-         },
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
          }
       },
       "node_modules/simple-concat": {
@@ -3507,6 +3795,7 @@
                "url": "https://feross.org/support"
             }
          ],
+         "license": "MIT",
          "optional": true
       },
       "node_modules/simple-get": {
@@ -3527,6 +3816,7 @@
                "url": "https://feross.org/support"
             }
          ],
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "decompress-response": "^6.0.0",
@@ -3543,9 +3833,10 @@
          }
       },
       "node_modules/source-map-js": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-         "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+         "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+         "license": "BSD-3-Clause",
          "engines": {
             "node": ">=0.10.0"
          }
@@ -3564,15 +3855,11 @@
          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
       },
-      "node_modules/stampit": {
-         "version": "4.3.2",
-         "resolved": "https://registry.npmjs.org/stampit/-/stampit-4.3.2.tgz",
-         "integrity": "sha512-pE2org1+ZWQBnIxRPrBM2gVupkuDD0TTNIo1H6GdT/vO82NXli2z8lRE8cu/nBIHrcOCXFBAHpb9ZldrB2/qOA=="
-      },
       "node_modules/string_decoder": {
          "version": "1.3.0",
          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "safe-buffer": "~5.2.0"
@@ -3582,6 +3869,7 @@
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+         "license": "MIT",
          "optional": true,
          "engines": {
             "node": ">=0.10.0"
@@ -3599,27 +3887,29 @@
          }
       },
       "node_modules/swagger-client": {
-         "version": "3.27.9",
-         "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.27.9.tgz",
-         "integrity": "sha512-7F7PnwSyIs+wBsX1rVkKDHXqwgVIX9aIl5O84eBcXEXLcrnndGS4C3n0Mk37+ZpJZN5uqv8MQKN6nQzhjsn6hQ==",
+         "version": "3.31.0",
+         "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.31.0.tgz",
+         "integrity": "sha512-hVYift5XB8nOgNJVl6cbNtVTVPT2Fdx2wCOcIvuAFcyq0Mwe6+70ezoZ5WfiaIAzzwWfq72jyaLeg8TViGNSmw==",
+         "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.22.15",
-            "@swagger-api/apidom-core": ">=0.99.2 <1.0.0",
-            "@swagger-api/apidom-error": ">=0.99.0 <1.0.0",
-            "@swagger-api/apidom-json-pointer": ">=0.99.2 <1.0.0",
-            "@swagger-api/apidom-ns-openapi-3-1": ">=0.99.2 <1.0.0",
-            "@swagger-api/apidom-reference": ">=0.99.2 <1.0.0",
-            "cookie": "~0.6.0",
+            "@scarf/scarf": "=1.4.0",
+            "@swagger-api/apidom-core": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+            "@swagger-api/apidom-error": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+            "@swagger-api/apidom-json-pointer": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+            "@swagger-api/apidom-ns-openapi-3-1": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+            "@swagger-api/apidom-reference": ">=1.0.0-alpha.9 <1.0.0-beta.0",
+            "cookie": "~0.7.2",
             "deepmerge": "~4.3.0",
             "fast-json-patch": "^3.0.0-1",
-            "is-plain-object": "^5.0.0",
             "js-yaml": "^4.1.0",
+            "neotraverse": "=0.6.18",
             "node-abort-controller": "^3.1.1",
             "node-fetch-commonjs": "^3.3.2",
             "openapi-path-templating": "^1.5.1",
-            "qs": "^6.10.2",
-            "ramda-adjunct": "^5.0.0",
-            "traverse": "=0.6.8"
+            "openapi-server-url-templating": "^1.0.0",
+            "ramda": "^0.30.1",
+            "ramda-adjunct": "^5.0.0"
          }
       },
       "node_modules/swagger-ui": {
@@ -3678,6 +3968,7 @@
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
          "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "chownr": "^1.1.1",
@@ -3690,6 +3981,7 @@
          "version": "2.2.0",
          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "bl": "^4.0.3",
@@ -3717,6 +4009,7 @@
          "version": "5.0.1",
          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+         "license": "MIT",
          "dependencies": {
             "is-number": "^7.0.0"
          },
@@ -3729,22 +4022,12 @@
          "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
          "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
       },
-      "node_modules/traverse": {
-         "version": "0.6.8",
-         "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
-         "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
-         "engines": {
-            "node": ">= 0.4"
-         },
-         "funding": {
-            "url": "https://github.com/sponsors/ljharb"
-         }
-      },
       "node_modules/tree-sitter": {
          "version": "0.20.4",
          "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.20.4.tgz",
          "integrity": "sha512-rjfR5dc4knG3jnJNN/giJ9WOoN1zL/kZyrS0ILh+eqq8RNcIbiXA63JsMEgluug0aNvfQvK4BfCErN1vIzvKog==",
          "hasInstallScript": true,
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "nan": "^2.17.0",
@@ -3756,6 +4039,7 @@
          "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.20.2.tgz",
          "integrity": "sha512-eUxrowp4F1QEGk/i7Sa+Xl8Crlfp7J0AXxX1QdJEQKQYMWhgMbCIgyQvpO3Q0P9oyTrNQxRLlRipDS44a8EtRw==",
          "hasInstallScript": true,
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "nan": "^2.18.0"
@@ -3766,6 +4050,7 @@
          "resolved": "https://registry.npmjs.org/tree-sitter-yaml/-/tree-sitter-yaml-0.5.0.tgz",
          "integrity": "sha512-POJ4ZNXXSWIG/W4Rjuyg36MkUD4d769YRUGKRqN+sVaj/VCo6Dh6Pkssn1Rtewd5kybx+jT1BWMyWN0CijXnMA==",
          "hasInstallScript": true,
+         "license": "MIT",
          "optional": true,
          "dependencies": {
             "nan": "^2.14.0"
@@ -3774,12 +4059,14 @@
       "node_modules/ts-mixer": {
          "version": "6.0.4",
          "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-         "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+         "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+         "license": "MIT"
       },
       "node_modules/ts-toolbelt": {
          "version": "9.6.0",
          "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
-         "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
+         "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+         "license": "Apache-2.0"
       },
       "node_modules/tslib": {
          "version": "2.5.0",
@@ -3790,6 +4077,7 @@
          "version": "0.6.0",
          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
          "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+         "license": "Apache-2.0",
          "optional": true,
          "dependencies": {
             "safe-buffer": "^5.0.1"
@@ -3799,9 +4087,10 @@
          }
       },
       "node_modules/types-ramda": {
-         "version": "0.29.10",
-         "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.10.tgz",
-         "integrity": "sha512-5PJiW/eiTPyXXBYGZOYGezMl6qj7keBiZheRwfjJZY26QPHsNrjfJnz0mru6oeqqoTHOni893Jfd6zyUXfQRWg==",
+         "version": "0.30.1",
+         "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+         "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+         "license": "MIT",
          "dependencies": {
             "ts-toolbelt": "^9.6.0"
          }
@@ -3817,7 +4106,8 @@
       "node_modules/unraw": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
-         "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+         "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
+         "license": "MIT"
       },
       "node_modules/url-parse": {
          "version": "1.5.10",
@@ -3840,17 +4130,19 @@
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/vite": {
-         "version": "5.2.11",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
-         "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
+         "version": "5.4.11",
+         "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+         "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
          "dev": true,
+         "license": "MIT",
          "dependencies": {
-            "esbuild": "^0.20.1",
-            "postcss": "^8.4.38",
-            "rollup": "^4.13.0"
+            "esbuild": "^0.21.3",
+            "postcss": "^8.4.43",
+            "rollup": "^4.20.0"
          },
          "bin": {
             "vite": "bin/vite.js"
@@ -3869,6 +4161,7 @@
             "less": "*",
             "lightningcss": "^1.21.0",
             "sass": "*",
+            "sass-embedded": "*",
             "stylus": "*",
             "sugarss": "*",
             "terser": "^5.4.0"
@@ -3886,6 +4179,9 @@
             "sass": {
                "optional": true
             },
+            "sass-embedded": {
+               "optional": true
+            },
             "stylus": {
                "optional": true
             },
@@ -3898,15 +4194,16 @@
          }
       },
       "node_modules/vue": {
-         "version": "3.4.27",
-         "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-         "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+         "version": "3.5.12",
+         "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.12.tgz",
+         "integrity": "sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/compiler-dom": "3.4.27",
-            "@vue/compiler-sfc": "3.4.27",
-            "@vue/runtime-dom": "3.4.27",
-            "@vue/server-renderer": "3.4.27",
-            "@vue/shared": "3.4.27"
+            "@vue/compiler-dom": "3.5.12",
+            "@vue/compiler-sfc": "3.5.12",
+            "@vue/runtime-dom": "3.5.12",
+            "@vue/server-renderer": "3.5.12",
+            "@vue/shared": "3.5.12"
          },
          "peerDependencies": {
             "typescript": "*"
@@ -3934,11 +4231,12 @@
          }
       },
       "node_modules/vue-router": {
-         "version": "4.3.2",
-         "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
-         "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
+         "version": "4.4.5",
+         "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.5.tgz",
+         "integrity": "sha512-4fKZygS8cH1yCyuabAXGUAsyi1b2/o/OKgu/RUb+znIYOxPRxdkytJEx+0wGcpBE1pX6vUgh5jwWOKRGvuA/7Q==",
+         "license": "MIT",
          "dependencies": {
-            "@vue/devtools-api": "^6.5.1"
+            "@vue/devtools-api": "^6.6.4"
          },
          "funding": {
             "url": "https://github.com/sponsors/posva"
@@ -3983,6 +4281,7 @@
          "version": "0.20.3",
          "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.20.3.tgz",
          "integrity": "sha512-zKGJW9r23y3BcJusbgvnOH2OYAW40MXAOi9bi3Gcc7T4Gms9WWgXF8m6adsJWpGJEhgOzCrfiz1IzKowJWrtYw==",
+         "license": "MIT",
          "optional": true
       },
       "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,23 +12,24 @@
       "@fortawesome/fontawesome-svg-core": "^1.2.36",
       "@fortawesome/free-solid-svg-icons": "^5.15.4",
       "@fortawesome/vue-fontawesome": "^3.0.3",
-      "@vue/compat": "^3.4.27",
+      "@vue/compat": "^3.5.11",
       "bootstrap-material-design": "^4.1.3",
-      "core-js": "^3.37.1",
+      "core-js": "^3.38.1",
       "jquery": "^3.7.1",
       "moment": "^2.30.1",
       "http-link-header": "^1.1.3",
       "popper.js": "^1.16.1",
-      "swagger-ui": "^4.19.0",
-      "vue": "^3.4.27",
-      "vue-router": "^4.3.2",
+      "swagger-ui": "^4.19.1",
+      "vue": "^3.5.12",
+      "vue-router": "^4.4.5",
       "vue-virtual-scroller": "^2.0.0-beta.8",
       "vuex": "^4.1.0"
    },
    "devDependencies": {
       "@rollup/plugin-inject": "^5.0.5",
-      "@vitejs/plugin-vue": "^5.0.4",
-      "sass": "1.77.1",
-      "vite": "^5.2.11"
+      "@vitejs/plugin-vue": "^5.1.4",
+      "sass": "1.79.5",
+      "vite": "^5.4.9"
    }
 }
+

--- a/frontend/src/Apps.vue
+++ b/frontend/src/Apps.vue
@@ -59,8 +59,6 @@
             v-on:changeState="changeServiceState"
             class="list-complete-item"/>
       </transition-group>
-
-      <router-view></router-view>
    </div>
 </template>
 

--- a/frontend/src/Main.vue
+++ b/frontend/src/Main.vue
@@ -1,0 +1,10 @@
+<template>
+   <Navbar/>
+   <main>
+      <RouterView />
+   </main>
+</template>
+
+<script setup>
+import Navbar from './Navbar.vue'
+</script>

--- a/frontend/src/Navbar.vue
+++ b/frontend/src/Navbar.vue
@@ -44,7 +44,8 @@
 
             <input class="form-control mr-sm-2" type="search" placeholder="Search Apps" aria-label="Search"
                    ref="searchApps"
-                   @keyup="fireSearchEvent">
+                   :value="appNameFilter"
+                   @input="fireSearchEvent">
 
             <a class="btn btn-outline-success my-2 my-sm-0"
                href="https://github.com/aixigo/PREvant" target="_blank">
@@ -69,6 +70,7 @@
 </style>
 
 <script>
+   import { mapGetters } from 'vuex';
    import OpenApiUI from './OpenApiUI.vue';
 
    export default {
@@ -78,9 +80,12 @@
       components: {
          'open-api-ui': OpenApiUI
       },
+      computed: {
+         ...mapGetters( [ 'appNameFilter' ] )
+      },
       methods: {
-         fireSearchEvent() {
-            this.$store.commit( 'filterByAppName', this.$refs.searchApps.value );
+         fireSearchEvent(e) {
+            this.$store.commit( 'filterByAppName', e.target.value);
          }
       }
    }

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -37,7 +37,8 @@ import { createApp, } from 'vue';
 import { createRouter, createWebHashHistory } from 'vue-router';
 
 import './scss/theme.scss';
-import App from './App.vue';
+import Main from './Main.vue';
+import Apps from './Apps.vue';
 import Navbar from './Navbar.vue';
 import OpenApiUI from './OpenApiUI.vue';
 import LogsDialog from './LogsDialog.vue';
@@ -45,7 +46,7 @@ import LogsDialog from './LogsDialog.vue';
 import {library} from '@fortawesome/fontawesome-svg-core';
 import {faClipboard, faCode, faCopy, faServer, faSpinner, faTerminal, faTrash, faWindowClose, faDownload} from '@fortawesome/free-solid-svg-icons';
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome';
-import store from './store';
+import { createStore } from './store';
 
 library.add(faClipboard);
 library.add(faCode);
@@ -57,25 +58,21 @@ library.add(faTerminal);
 library.add(faTrash);
 library.add(faWindowClose);
 
-store.dispatch('fetchData');
-
-const router = createRouter({
+export const router = createRouter({
    history: createWebHashHistory(),
    routes: [
+      { path: '/', component: Apps, query: { appNameFilter: { type: String } } },
       { path: '/open-api-ui/:url', name: 'open-api-ui', component: OpenApiUI },
       { path: '/logs/:app/:service', name: 'logs', component: LogsDialog }
    ]
 });
 
-createApp(App)
-   .component('font-awesome-icon', FontAwesomeIcon)
-   .use(store)
-   .use(router)
-   .mount('#app')
+const store = createStore(router);
+store.dispatch('fetchData');
 
-createApp(Navbar)
+createApp(Main)
    .component('font-awesome-icon', FontAwesomeIcon)
    .use(store)
    .use(router)
-   .mount('#nav')
+   .mount('#main')
 


### PR DESCRIPTION
This commit makes sure that app names will be limited to valid characters for Kubernetes backend. Also the duplicate UI shows the client error now.

Additionally, the filtering of app names in the dashboard will be persisted in the URL route so you can refresh the pages and keep the app name filtering.

Fixes #215 