### PR TITLE
Fix that closing a dialog with 'X' does nothing when the user has no browsing history

### DIFF
--- a/frontend/src/AsyncApiUI.vue
+++ b/frontend/src/AsyncApiUI.vue
@@ -44,7 +44,11 @@ export default {
    },
    methods: {
       close() {
-         this.$router.back();
+        if (window.history.length > 1) {
+          this.$router.back()
+        } else {
+          this.$router.push('/')
+        }
       }
    }
 }

--- a/frontend/src/LogsDialog.vue
+++ b/frontend/src/LogsDialog.vue
@@ -171,7 +171,11 @@
             if (this.eventSource) {
                this.eventSource.close();
             }
-            this.$router.back();
+            if (window.history.length > 1) {
+              this.$router.back()
+            } else {
+              this.$router.push('/')
+            }
          },
 
          scrollBottom() {

--- a/frontend/src/OpenApiUI.vue
+++ b/frontend/src/OpenApiUI.vue
@@ -135,7 +135,11 @@
       },
       methods: {
          close() {
-            this.$router.back();
+           if (window.history.length > 1) {
+             this.$router.back()
+           } else {
+             this.$router.push('/')
+           }
          }
       }
    }


### PR DESCRIPTION
Fixed a bug that was introduced with [this commit](https://github.com/aixigo/PREvant/commit/e6c1f6a6ac9237e8b087b0be73bbcf2857b02cb5) that would cause a user, that directly navigated to a dialog via an URL, to not be able to close this dialog.