### PR TITLE
Testing Named Service Port

### DIFF
--- a/examples/Kubernetes/Dockerfile.bootstrap
+++ b/examples/Kubernetes/Dockerfile.bootstrap
@@ -69,9 +69,7 @@ spec:
             pathType: Prefix
             backend:
                service:
-                  name: httpd
-                  port:
-                    number: 80
+                  name: web
 EOI
 EOF
 


### PR DESCRIPTION
This commit ensures that the named service port matching when converting Kubernetes ingresses to Traefik ingresses is tested via integration tests.