### PR TITLE
fix(frontend): navigate to correct url when closing dialogs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,37 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Playwright Tests
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        working-directory: frontend
+        run: npm run test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
 target/
 node_modules/
+test-results/
+playwright-report/
 

--- a/docs/Develop.md
+++ b/docs/Develop.md
@@ -64,7 +64,6 @@ To build the static HTML files that can be served by PREvant's backend:
 Afterwards, start the backend (see [Backend Development](#backend-development)). PREvant will then be accessible at:  
 **http://localhost:8000**
 
-
 ## <a name="fe-dev-server"></a>Frontend Development Server
 
 To run the frontend in development mode:
@@ -82,15 +81,13 @@ To run the frontend in development mode:
    npm ci
    npm run serve
    ```
-   
+
 4. Open the following URL in your browser:  
    **http://localhost:9001**
 
 ## Frontend Tests
 
 We use [Playwright](https://playwright.dev/) for end-to-end testing.
-
-### Setup
 
 Before running the tests for the first time, you must install the required browsers:
 
@@ -99,8 +96,6 @@ npx playwright install
 ```
 
 This only needs to be done once (or whenever Playwright updates its browser requirements).
-
-### Run Tests
 
 To run the Playwright tests:
 

--- a/docs/Develop.md
+++ b/docs/Develop.md
@@ -6,7 +6,7 @@ You can build PREvant's backend API with [`cargo`](https://doc.rust-lang.org/car
 
 When you than interact with the REST API to deploy service, it is worthwhile to have a look into the [Traefik dashboard](https://doc.traefik.io/traefik/operations/dashboard/#the-dashboard) to double check if PREvant exposes the services as expected.
 
-If you want to use PREvant's frontend during development, head over to the [Frontend Development section](#fe-dev).
+If you want to use PREvant's frontend during development, head over to the [Frontend Development section](#frontend-development).
 
 Without any CLI options, PREvant will use the Docker API. If you want to develop with against Kubernetes, have a look into the [Kubernetes section](#k8s-dev).
 
@@ -40,32 +40,79 @@ For developing against a local Kubernetes cluster you can use [k3d].
    kubectl -n kube-system port-forward $(kubectl -n kube-system get pods --selector "app.kubernetes.io/name=traefik" --output name) 9000:9000
    ```
 
-# <a name="fe-dev"></a>Frontend Development
+# Frontend Development
 
-You can build PREvant's frontend with [`npm`](https://www.npmjs.com/) in the sub directory `/frontend`. You can [build the static HTML files](#fe-static-html) or [serve the HTML files via the dev server](#fe-dev-server).
+PREvant’s frontend is located in the `/frontend` directory and uses [`npm`](https://www.npmjs.com/) for development and builds. You can either [build the static HTML files](#frontend-static-html-build) or [run the development server](#frontend-development-server). There is also a section on how to [run the frontend tests](#frontend-tests).
+
+## Frontend Static HTML Build
+
+To build the static HTML files that can be served by PREvant's backend:
+
+1. Change into the `/frontend` directory:
+   ```bash
+   cd frontend
+   ```
+2. Install dependencies:
+   ```bash
+   npm ci
+   ```
+3. Build the frontend:
+   ```bash
+   npm run build
+   ```
+
+Afterwards, start the backend (see [Backend Development](#backend-development)). PREvant will then be accessible at:  
+**http://localhost:8000**
 
 
-## <a name="fe-static-html"></a>Static HTML
+## Frontend Development Server
 
-To create the static HTML files that can be served by PREvant's backend (see [above](#backend-development), you need to run following commands and start the backend.
-
-```bash
-npm ci
-npm run build
-```
-
-PREvant will be available at `http://localhost:8000`.
-
-## <a name="fe-dev-server"></a>Dev Server
+To run the frontend in development mode:
 
 1. Start the backend as described in [Backend Development](#backend-development).
-2. Change into the directory `/frontend`
-3. Build and run the frontend in the development mode
+2. Navigate to the `/frontend` directory:
+
+   ```bash
+   cd frontend
+   ```
+
+3. Install dependencies and start the dev server:
+
    ```bash
    npm ci
    npm run serve
    ```
-4. Open the URL `http://localhost:9001` in your browser
+   
+4. Open the following URL in your browser:  
+   **http://localhost:9001**
+
+## Frontend Tests
+
+We use [Playwright](https://playwright.dev/) for end-to-end testing.
+
+### Setup
+
+Before running the tests for the first time, you must install the required browsers:
+
+```bash
+npx playwright install
+```
+
+This only needs to be done once (or whenever Playwright updates its browser requirements).
+
+### Run Tests
+
+To run the Playwright tests:
+
+```bash
+npm run test:e2e
+```
+
+Alternatively, you can run the tests in debug mode (with a UI):
+
+```bash
+npm run test:e2e:ui
+```
 
 # Integration Testing
 

--- a/docs/Develop.md
+++ b/docs/Develop.md
@@ -40,11 +40,11 @@ For developing against a local Kubernetes cluster you can use [k3d].
    kubectl -n kube-system port-forward $(kubectl -n kube-system get pods --selector "app.kubernetes.io/name=traefik" --output name) 9000:9000
    ```
 
-# Frontend Development
+# <a name="fe-dev"></a>Frontend Development
 
 PREvant’s frontend is located in the `/frontend` directory and uses [`npm`](https://www.npmjs.com/) for development and builds. You can either [build the static HTML files](#frontend-static-html-build) or [run the development server](#frontend-development-server). There is also a section on how to [run the frontend tests](#frontend-tests).
 
-## Frontend Static HTML Build
+## <a name="fe-static-html"></a>Frontend Static HTML Build
 
 To build the static HTML files that can be served by PREvant's backend:
 
@@ -65,7 +65,7 @@ Afterwards, start the backend (see [Backend Development](#backend-development)).
 **http://localhost:8000**
 
 
-## Frontend Development Server
+## <a name="fe-dev-server"></a>Frontend Development Server
 
 To run the frontend in development mode:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
             "vuex": "^4.1.0"
          },
          "devDependencies": {
+            "@playwright/test": "^1.53.1",
             "@rollup/plugin-inject": "^5.0.5",
             "@vitejs/plugin-vue": "^5.2.1",
             "sass": "1.79.5",
@@ -1153,6 +1154,22 @@
          },
          "engines": {
             "node": ">=0.10"
+         }
+      },
+      "node_modules/@playwright/test": {
+         "version": "1.53.1",
+         "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+         "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "playwright": "1.53.1"
+         },
+         "bin": {
+            "playwright": "cli.js"
+         },
+         "engines": {
+            "node": ">=18"
          }
       },
       "node_modules/@protobufjs/aspromise": {
@@ -5013,6 +5030,53 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/jonschlinkert"
+         }
+      },
+      "node_modules/playwright": {
+         "version": "1.53.1",
+         "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+         "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "dependencies": {
+            "playwright-core": "1.53.1"
+         },
+         "bin": {
+            "playwright": "cli.js"
+         },
+         "engines": {
+            "node": ">=18"
+         },
+         "optionalDependencies": {
+            "fsevents": "2.3.2"
+         }
+      },
+      "node_modules/playwright-core": {
+         "version": "1.53.1",
+         "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+         "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+         "dev": true,
+         "license": "Apache-2.0",
+         "bin": {
+            "playwright-core": "cli.js"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
+      "node_modules/playwright/node_modules/fsevents": {
+         "version": "2.3.2",
+         "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+         "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+         "dev": true,
+         "hasInstallScript": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ],
+         "engines": {
+            "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
          }
       },
       "node_modules/pony-cause": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
    "private": true,
    "scripts": {
       "serve": "vite",
-      "build": "vite build"
+      "build": "vite build",
+      "test:e2e": "playwright test",
+      "test:e2e:ui": "playwright test --ui"
    },
    "dependencies": {
       "@asyncapi/react-component": "^2.5.0",
@@ -16,9 +18,9 @@
       "@vue/compat": "^3.5.13",
       "bootstrap-material-design": "^4.1.3",
       "core-js": "^3.40.0",
+      "http-link-header": "^1.1.3",
       "jquery": "^3.7.1",
       "moment": "^2.30.1",
-      "http-link-header": "^1.1.3",
       "popper.js": "^1.16.1",
       "swagger-ui": "^5.18.2",
       "vue": "^3.5.13",
@@ -27,10 +29,10 @@
       "vuex": "^4.1.0"
    },
    "devDependencies": {
+      "@playwright/test": "^1.53.1",
       "@rollup/plugin-inject": "^5.0.5",
       "@vitejs/plugin-vue": "^5.2.1",
       "sass": "1.79.5",
       "vite": "^5.4.14"
    }
 }
-

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run serve', 
+    port: 9001,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:9001',
+    headless: true,
+  },
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,14 +1,19 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }],
+    ...(process.env.CI ? [["github"]] : []),
+  ],
   webServer: {
-    command: 'npm run serve', 
+    command: "npm run serve",
     port: 9001,
     reuseExistingServer: !process.env.CI,
   },
   use: {
-    baseURL: 'http://localhost:9001',
+    baseURL: "http://localhost:9001",
     headless: true,
   },
 });

--- a/frontend/src/Apps.vue
+++ b/frontend/src/Apps.vue
@@ -44,7 +44,6 @@
             v-for="reviewApp in appsWithoutTicket(reviewApps)"
             :key="reviewApp.name"
             :review-app="reviewApp"
-            v-on:showLogs="showServiceLogs"
             v-on:changeState="changeServiceState"
             class="list-complete-item"/>
       </transition-group>
@@ -119,12 +118,6 @@
          appsWithoutTicket( apps ) {
             const self = this;
             return apps.filter( app => self.$store.state.tickets[ app.name ] === undefined );
-         },
-
-         showServiceLogs( appName, serviceName ) {
-            this.selectLogs.appName = appName;
-            this.selectLogs.serviceName = serviceName;
-            this.$refs.logsDialog.open();
          },
 
          changeServiceState( appName, serviceName ) {

--- a/frontend/src/AsyncApiUI.vue
+++ b/frontend/src/AsyncApiUI.vue
@@ -8,7 +8,7 @@
                   <h1>AsyncAPI Documentation<span v-if="showAdditionalHeadlineInformation"> – {{ $route.params.title }}</span></h1>
 
                   <span @click="close()">
-                     <font-awesome-icon icon="window-close" @click="close()" class="ra-modal-close-button"/>
+                     <font-awesome-icon icon="window-close" class="ra-modal-close-button" aria-label="Close"/>
                   </span>
                </div>
 
@@ -44,11 +44,7 @@ export default {
    },
    methods: {
       close() {
-        if (window.history.length > 1) {
-          this.$router.back()
-        } else {
-          this.$router.push('/')
-        }
+        this.$router.push(this.$router.options.history.state.back ?? "/");
       }
    }
 }

--- a/frontend/src/LogsDialog.vue
+++ b/frontend/src/LogsDialog.vue
@@ -171,11 +171,7 @@
             if (this.eventSource) {
                this.eventSource.close();
             }
-            if (window.history.length > 1) {
-              this.$router.back()
-            } else {
-              this.$router.push('/')
-            }
+            this.$router.push(this.$router.options.history.state.back ?? "/");
          },
 
          scrollBottom() {

--- a/frontend/src/OpenApiUI.vue
+++ b/frontend/src/OpenApiUI.vue
@@ -33,7 +33,7 @@
                   <h1>API Documentation<span v-if="showAdditionalHeadlineInformation"> – {{ $route.params.title }}</span></h1>
 
                   <span @click="close()">
-                     <font-awesome-icon icon="window-close" @click="close()" class="ra-modal-close-button"/>
+                     <font-awesome-icon icon="window-close" class="ra-modal-close-button" aria-label="Close"/>
                   </span>
                </div>
 
@@ -135,11 +135,7 @@
       },
       methods: {
          close() {
-           if (window.history.length > 1) {
-             this.$router.back()
-           } else {
-             this.$router.push('/')
-           }
+           this.$router.push(this.$router.options.history.state.back ?? "/");
          }
       }
    }

--- a/frontend/tests/app-modal-dialogs.spec.js
+++ b/frontend/tests/app-modal-dialogs.spec.js
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+
+const PREVIEW_NAME = "master";
+const SERVICE_NAME = "whoami";
+const FILTER_STRING = PREVIEW_NAME.substring(0, 4);
+const mockedApps = {
+  [PREVIEW_NAME]: [
+    {
+      name: SERVICE_NAME,
+      url: `http://localhost:9001/${PREVIEW_NAME}/${SERVICE_NAME}/`,
+      type: "service",
+      state: { status: "running" },
+      openApiUrl: `http://localhost:9001/${PREVIEW_NAME}/${SERVICE_NAME}/swagger.json`,
+      asyncApiUrl: `http://localhost:9001/${PREVIEW_NAME}/${SERVICE_NAME}/asyncApi.json`,
+    },
+  ],
+};
+
+// We need to use this format because the apps are fetched using event streams
+const mockedAppsAsEventStream = `
+data:${JSON.stringify(mockedApps)}
+:
+
+
+`; // The empty lines at the end are important. Do not delete them!
+
+test.describe("app modal dialogs", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/apps", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "text/event-stream;charset=UTF-8",
+        body: mockedAppsAsEventStream,
+      });
+    });
+  });
+
+  test.describe("when entering through the home page and filtering the apps", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/");
+
+      // Wait for preview and service
+      await expect(
+        page.getByRole("heading", { name: PREVIEW_NAME })
+      ).toBeVisible();
+      await expect(page.getByText(SERVICE_NAME)).toBeVisible();
+
+      // Apply filter
+      const filterInput = page.getByPlaceholder("Search Apps");
+      await filterInput.fill(FILTER_STRING);
+
+      // Ensure preview and service are still visible after filter
+      await expect(
+        page.getByRole("heading", { name: PREVIEW_NAME })
+      ).toBeVisible();
+      await expect(page.getByText(SERVICE_NAME)).toBeVisible();
+    });
+
+    test.afterEach(async ({ page }) => {
+      // Close modal
+      await page.getByLabel("Close").click();
+
+      // Ensure query param is preserved
+      await expect(page).toHaveURL(
+        new RegExp(`.*\\?appNameFilter=${FILTER_STRING}.*`)
+      );
+    });
+
+    test("should retain query param after closing Logs dialog", async ({
+      page,
+    }) => {
+      // open Logs
+      await page.click(
+        `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Logs")`
+      );
+
+      // make sure dialog is visible
+      await expect(
+        page.getByRole("heading", {
+          name: `Logs of ${SERVICE_NAME} in ${PREVIEW_NAME}`,
+        })
+      ).toBeVisible();
+    });
+
+    test("should retain query param after closing Open API Documentation dialog", async ({
+      page,
+    }) => {
+      // open Open API Documentation
+      await page.click(
+        `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Open API Documentation")`
+      );
+
+      // make sure dialog is visible
+      await expect(
+        page.getByRole("heading", {
+          name: `API Documentation`,
+        })
+      ).toBeVisible();
+    });
+
+    test("should retain query param after closing Async API Documentation dialog", async ({
+      page,
+    }) => {
+      // open Async API Documentation
+      await page.click(
+        `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Async API Documentation")`
+      );
+
+      // make sure dialog is visible
+      await expect(
+        page.getByRole("heading", {
+          name: "AsyncAPI Documentation",
+        })
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("when opening the Logs dialog via direct URL", () => {
+    test("should navigate to home when closing the dialog and not close the tab or navigate to a 3rd party site", async ({
+      page,
+    }) => {
+      // Go directly to logs dialog URL
+      await page.goto(`/#/logs/${PREVIEW_NAME}/${SERVICE_NAME}`);
+
+      // Make sure logs dialog is visible
+      await expect(
+        page.getByRole("heading", {
+          name: `Logs of ${SERVICE_NAME} in ${PREVIEW_NAME}`,
+        })
+      ).toBeVisible();
+
+      // Close the dialog
+      await page.getByLabel("Close").click();
+
+      // Ensure we're on the home page (no previous page fallback, no tab close)
+      await expect(page).toHaveURL(/\/#\/$/);
+    });
+  });
+});

--- a/frontend/tests/app-modal-dialogs.spec.js
+++ b/frontend/tests/app-modal-dialogs.spec.js
@@ -39,29 +39,35 @@ test.describe("app modal dialogs", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto("/");
 
-      // Wait for preview and service
       await expect(
-        page.getByRole("heading", { name: PREVIEW_NAME })
+        page.getByRole("heading", { name: PREVIEW_NAME }),
+        `preview "${PREVIEW_NAME}" should be visible after initial loading`
       ).toBeVisible();
-      await expect(page.getByText(SERVICE_NAME)).toBeVisible();
+      await expect(
+        page.getByText(SERVICE_NAME),
+        `service "${SERVICE_NAME}" should be visible after initial loading`
+      ).toBeVisible();
 
       // Apply filter
       const filterInput = page.getByPlaceholder("Search Apps");
       await filterInput.fill(FILTER_STRING);
 
-      // Ensure preview and service are still visible after filter
       await expect(
-        page.getByRole("heading", { name: PREVIEW_NAME })
+        page.getByRole("heading", { name: PREVIEW_NAME }),
+        `preview "${PREVIEW_NAME}" should remain visible after filtering`
       ).toBeVisible();
-      await expect(page.getByText(SERVICE_NAME)).toBeVisible();
+
+      await expect(
+        page.getByText(SERVICE_NAME),
+        `service "${SERVICE_NAME}" should remain visible after filtering`
+      ).toBeVisible();
     });
 
     test.afterEach(async ({ page }) => {
       // Close modal
       await page.getByLabel("Close").click();
 
-      // Ensure query param is preserved
-      await expect(page).toHaveURL(
+      await expect(page, "query parameter should be preserved").toHaveURL(
         new RegExp(`.*\\?appNameFilter=${FILTER_STRING}.*`)
       );
     });
@@ -74,11 +80,11 @@ test.describe("app modal dialogs", () => {
         `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Logs")`
       );
 
-      // make sure dialog is visible
       await expect(
         page.getByRole("heading", {
           name: `Logs of ${SERVICE_NAME} in ${PREVIEW_NAME}`,
-        })
+        }),
+        "logs dialog should be visible"
       ).toBeVisible();
     });
 
@@ -90,11 +96,11 @@ test.describe("app modal dialogs", () => {
         `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Open API Documentation")`
       );
 
-      // make sure dialog is visible
       await expect(
         page.getByRole("heading", {
           name: `API Documentation`,
-        })
+        }),
+        "OpenApi dialog should be visible"
       ).toBeVisible();
     });
 
@@ -106,11 +112,11 @@ test.describe("app modal dialogs", () => {
         `div.card:has(.card-header:has-text("${PREVIEW_NAME}")):has(.card-body a:text("${SERVICE_NAME}")) a:text("Async API Documentation")`
       );
 
-      // make sure dialog is visible
       await expect(
         page.getByRole("heading", {
           name: "AsyncAPI Documentation",
-        })
+        }),
+        "AsyncAPI dialog should be visible"
       ).toBeVisible();
     });
   });
@@ -122,18 +128,20 @@ test.describe("app modal dialogs", () => {
       // Go directly to logs dialog URL
       await page.goto(`/#/logs/${PREVIEW_NAME}/${SERVICE_NAME}`);
 
-      // Make sure logs dialog is visible
       await expect(
         page.getByRole("heading", {
           name: `Logs of ${SERVICE_NAME} in ${PREVIEW_NAME}`,
-        })
+        }),
+        "logs dialog should be visible"
       ).toBeVisible();
 
       // Close the dialog
       await page.getByLabel("Close").click();
 
-      // Ensure we're on the home page (no previous page fallback, no tab close)
-      await expect(page).toHaveURL(/\/#\/$/);
+      await expect(
+        page,
+        "should naviate to home page and not any other previous page or close the tab"
+      ).toHaveURL(/\/#\/$/);
     });
   });
 });


### PR DESCRIPTION
This PR fixes a regression introduced in #245 and #247 related to preserving the `filter` query parameter and navigation behavior when closing dialogs.

# Background

- #245 introduced the feature to retain the `filter` query parameter when closing dialogs.
- However, this caused an issue when dialogs were accessed directly via URL: navigating back would either close the browser tab or navigate to an external (3rd party) website.
- #247 attempted to fix this, but the fix was incomplete.

# Root Cause

The problem stems from using `window.history` with `$router.back()`. Since the browser history may contain external pages or even `about:` URL from the browser, relying on `window.history` can lead to unexpected behavior or navigation errors.

# What’s Changed

- Instead of `$router.back()`, this PR uses `$router.options.history.state.back` (when available) to navigate to the previous Vue route safely.
- If no valid back route exists, the app will navigate to the home page as a fallback.
- Added Playwright end-to-end tests to prevent future regressions related to this behavior.
