### PR TITLE
Hook for Mapping ID Token Claims

### DIFF
--- a/api/src/apps/routes/mod.rs
+++ b/api/src/apps/routes/mod.rs
@@ -310,12 +310,11 @@ impl From<AppsError> for HttpApiError {
             AppsError::AppNotFound { .. } => StatusCode::NOT_FOUND,
             AppsError::AppIsInDeployment { .. } => StatusCode::CONFLICT,
             AppsError::AppIsInDeletion { .. } => StatusCode::CONFLICT,
-            AppsError::FailedToParseTraefikRule { .. }
-            | AppsError::InfrastructureError { .. }
+            AppsError::InfrastructureError { .. }
             | AppsError::InvalidServerConfiguration { .. }
-            | AppsError::InvalidTemplateFormat { .. }
-            | AppsError::InvalidDeploymentHook => {
-                error!("Internal server error: {}", error);
+            | AppsError::TemplatingIssue { .. }
+            | AppsError::UnapplicableHook { .. } => {
+                error!("Internal server error: {error}");
                 StatusCode::INTERNAL_SERVER_ERROR
             }
         };

--- a/api/src/auth/user.rs
+++ b/api/src/auth/user.rs
@@ -1,0 +1,138 @@
+use openidconnect::{core::CoreGenderClaim, IdTokenClaims};
+use serde::{Deserialize, Serialize};
+
+pub enum User {
+    Anonymous,
+    Oidc {
+        id_token_claims: IdTokenClaims<AdditionalClaims, CoreGenderClaim>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdditionalClaims(serde_json::Value);
+
+impl AdditionalClaims {
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self(serde_json::Value::Object(serde_json::Map::new()))
+    }
+    #[cfg(test)]
+    pub fn with_claims(claims: serde_json::Value) -> Self {
+        assert!(claims.is_object());
+        Self(claims)
+    }
+}
+
+impl openidconnect::AdditionalClaims for AdditionalClaims {}
+impl openidconnect::ExtraTokenFields for AdditionalClaims {}
+
+impl Serialize for AdditionalClaims {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AdditionalClaims {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self(serde_json::Value::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_json_diff::assert_json_eq;
+    use chrono::TimeZone;
+    use openidconnect::{IssuerUrl, StandardClaims, SubjectIdentifier};
+
+    #[test]
+    fn serialize_additional_claims() {
+        let claims = IdTokenClaims::<AdditionalClaims, CoreGenderClaim>::new(
+            IssuerUrl::new(String::from("https://gitlab.com")).unwrap(),
+            Vec::new(),
+            chrono::Utc.with_ymd_and_hms(2025, 5, 1, 0, 0, 0).unwrap(),
+            chrono::Utc.with_ymd_and_hms(2025, 5, 1, 0, 30, 0).unwrap(),
+            StandardClaims::new(SubjectIdentifier::new(String::from("gitlab-user"))),
+            AdditionalClaims::with_claims(serde_json::json!({ "user_id": "1234566" })),
+        );
+
+        assert_json_eq!(
+            claims,
+            serde_json::json!({
+                "sub": "gitlab-user",
+                "aud": [],
+                "exp": 1746057600,
+                "iat": 1746059400,
+                "iss": "https://gitlab.com",
+                "user_id": "1234566"
+            })
+        )
+    }
+
+    #[test]
+    fn deserialize_additional_claims() {
+        let token = serde_json::from_value::<IdTokenClaims<AdditionalClaims, CoreGenderClaim>>(
+            serde_json::json!({
+                "sub": "gitlab-user",
+                "aud": [],
+                "exp": 1746057600,
+                "iat": 1746059400,
+                "iss": "https://gitlab.com",
+                "user_id": "1234566"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            token.additional_claims(),
+            &AdditionalClaims::with_claims(serde_json::json!({
+                "user_id": "1234566"
+            }))
+        )
+    }
+
+    #[test]
+    fn serialize_empty_additional_claims() {
+        let claims = IdTokenClaims::<AdditionalClaims, CoreGenderClaim>::new(
+            IssuerUrl::new(String::from("https://gitlab.com")).unwrap(),
+            Vec::new(),
+            chrono::Utc.with_ymd_and_hms(2025, 5, 1, 0, 0, 0).unwrap(),
+            chrono::Utc.with_ymd_and_hms(2025, 5, 1, 0, 30, 0).unwrap(),
+            StandardClaims::new(SubjectIdentifier::new(String::from("gitlab-user"))),
+            AdditionalClaims::empty(),
+        );
+
+        assert_json_eq!(
+            claims,
+            serde_json::json!({
+                "sub": "gitlab-user",
+                "aud": [],
+                "exp": 1746057600,
+                "iat": 1746059400,
+                "iss": "https://gitlab.com",
+            })
+        )
+    }
+
+    #[test]
+    fn deserialize_empty_additional_claims() {
+        let token = serde_json::from_value::<IdTokenClaims<AdditionalClaims, CoreGenderClaim>>(
+            serde_json::json!({
+                "sub": "gitlab-user",
+                "aud": [],
+                "exp": 1746057600,
+                "iat": 1746059400,
+                "iss": "https://gitlab.com",
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(token.additional_claims(), &AdditionalClaims::empty())
+    }
+}

--- a/api/src/deployment/hooks.rs
+++ b/api/src/deployment/hooks.rs
@@ -1,3 +1,4 @@
+use crate::auth::User;
 /*-
  * ========================LICENSE_START=================================
  * PREvant REST API
@@ -23,79 +24,188 @@
  * THE SOFTWARE.
  * =========================LICENSE_END==================================
  */
-use crate::apps::AppsServiceError;
+use super::deployment_unit::DeployableService;
 use crate::config::Config;
-use crate::models::{AppName, ContainerType, Environment, EnvironmentVariable, Image};
+use crate::models::{AppName, ContainerType, Environment, EnvironmentVariable, Image, Owner};
 use boa_engine::property::Attribute;
 use boa_engine::{Context, JsValue, Source};
 use log::error;
+use openidconnect::core::CoreGenderClaim;
+use openidconnect::IdTokenClaims;
 use secstr::SecUtf8;
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::iter::IntoIterator;
-use std::path::{Path, PathBuf};
-
-use super::deployment_unit::DeployableService;
+use std::path::PathBuf;
 
 pub struct Hooks<'a> {
-    hook_config: &'a Config,
+    config: &'a Config,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum HooksError {
+    #[error("Invalid deployment hook, {err}")]
+    InvalidDeploymentHook { err: String },
+    #[error("Invalid user-to-owner hook execution: {err}")]
+    UserToOwner { err: String },
+    #[error("Unexpected err during hook execution: {err}")]
+    Unexpected { err: String },
+    #[error("Expected function {expected} is not present in hook file {file}")]
+    ExpectedFunctionNotPresent { expected: String, file: PathBuf },
 }
 
 impl<'a> Hooks<'a> {
-    pub fn new(hook_config: &'a Config) -> Self {
-        Hooks { hook_config }
+    pub fn new(config: &'a Config) -> Self {
+        Hooks { config }
+    }
+
+    pub async fn apply_id_token_claims_to_owner_hook(
+        &self,
+        user: User,
+    ) -> Result<Option<Owner>, HooksError> {
+        let User::Oidc { id_token_claims } = user else {
+            return Ok(None);
+        };
+
+        let Some(id_token_claims_to_owner_hook_path) =
+            self.config.hook("idTokenClaimsToOwner").cloned()
+        else {
+            return Ok(Some(Owner {
+                sub: id_token_claims.subject().clone(),
+                iss: id_token_claims.issuer().clone(),
+                name: id_token_claims
+                    .name()
+                    .and_then(|name| name.get(None))
+                    .map(|name| name.to_string()),
+            }));
+        };
+
+        let hook_content = match tokio::fs::read_to_string(&id_token_claims_to_owner_hook_path)
+            .await
+        {
+            Ok(hook_content) => hook_content,
+            Err(err) => {
+                let err =
+                    format!("Cannot read hook file {id_token_claims_to_owner_hook_path:?}: {err}");
+                log::error!("{err}");
+                return Err(HooksError::UserToOwner { err });
+            }
+        };
+
+        let join = tokio::task::spawn_blocking(move || {
+            let context = Self::parse_hook(
+                id_token_claims_to_owner_hook_path.to_path_buf(),
+                &hook_content,
+                "idTokenClaimsToOwnerHook",
+            )?;
+            Self::run_id_token_claims_to_owner_hook(id_token_claims, context)
+        });
+
+        join.await
+            .map_err(|err| HooksError::Unexpected {
+                err: err.to_string(),
+            })?
+            .map(Some)
+    }
+
+    fn run_id_token_claims_to_owner_hook(
+        id_token_claims: IdTokenClaims<crate::auth::AdditionalClaims, CoreGenderClaim>,
+        mut context: Context,
+    ) -> Result<Owner, HooksError> {
+        let id_token_claims = JsValue::from_json(
+            &serde_json::to_value(&id_token_claims).expect("Unable to serialize token claims"),
+            &mut context,
+        )
+        .expect("Unable to read JSON value");
+
+        context
+            .register_global_property(
+                boa_engine::js_string!("idTokenClaims"),
+                id_token_claims,
+                Attribute::READONLY,
+            )
+            .expect("Property registration failed unexpectedly");
+
+        let owner = context
+            .eval(Source::from_bytes(
+                "idTokenClaimsToOwnerHook(idTokenClaims)",
+            ))
+            .map_err(|err| HooksError::UserToOwner {
+                err: format!("Cannot execute hook: {err}"),
+            })?;
+
+        serde_json::from_value::<Owner>(owner.to_json(&mut context).unwrap()).map_err(|err| {
+            HooksError::UserToOwner {
+                err: err.to_string(),
+            }
+        })
     }
 
     pub async fn apply_deployment_hook(
         &self,
         app_name: &AppName,
         services: Vec<DeployableService>,
-    ) -> Result<Vec<DeployableService>, AppsServiceError> {
-        match self.hook_config.hook("deployment") {
-            None => Ok(services),
-            Some(hook_path) => self.parse_and_run_hook(app_name, services, hook_path).await,
-        }
-    }
+    ) -> Result<Vec<DeployableService>, HooksError> {
+        let Some(deployment_hook_path) = self.config.hook("deployment").cloned() else {
+            return Ok(services);
+        };
 
-    async fn parse_and_run_hook(
-        &self,
-        app_name: &AppName,
-        services: Vec<DeployableService>,
-        hook_path: &Path,
-    ) -> Result<Vec<DeployableService>, AppsServiceError> {
-        match Self::parse_hook(hook_path).await {
-            Some(mut context) => {
-                Self::register_configs_as_global_property(&mut context, &services);
-                context
-                    .register_global_property(
-                        boa_engine::js_string!("appName"),
-                        JsValue::String(app_name.to_string().into()),
-                        Attribute::READONLY,
-                    )
-                    .expect("Property registration failed unexpectedly");
-
-                let transformed_configs = context
-                    .eval(Source::from_bytes(
-                        "deploymentHook(appName, serviceConfigs)",
-                    ))
-                    .unwrap();
-
-                let transformed_configs = transformed_configs.to_json(&mut context).unwrap();
-
-                Self::parse_service_config(services, transformed_configs)
-            }
-            None => Ok(services),
-        }
-    }
-
-    async fn parse_hook(hook_path: &Path) -> Option<Context> {
-        let hook_content = match tokio::fs::read_to_string(hook_path).await {
+        let hook_content = match tokio::fs::read_to_string(&deployment_hook_path).await {
             Ok(hook_content) => hook_content,
             Err(err) => {
-                error!("Cannot read hook file {:?}: {}", hook_path, err);
-                return None;
+                let err = format!("Cannot read hook file {deployment_hook_path:?}: {err}");
+                error!("{err}");
+                return Err(HooksError::InvalidDeploymentHook { err });
             }
         };
 
+        let app_name = app_name.clone();
+        let join = tokio::task::spawn_blocking(move || {
+            let context = Self::parse_hook(
+                deployment_hook_path.to_path_buf(),
+                &hook_content,
+                "deploymentHook",
+            )?;
+            Self::run_deployment_hook(app_name, services, context)
+        });
+
+        join.await.map_err(|err| HooksError::Unexpected {
+            err: err.to_string(),
+        })?
+    }
+
+    fn run_deployment_hook(
+        app_name: AppName,
+        services: Vec<DeployableService>,
+        mut context: Context,
+    ) -> Result<Vec<DeployableService>, HooksError> {
+        Self::register_configs_as_global_property(&mut context, &services);
+        context
+            .register_global_property(
+                boa_engine::js_string!("appName"),
+                JsValue::String(app_name.into_string().into()),
+                Attribute::READONLY,
+            )
+            .expect("Property registration failed unexpectedly");
+
+        let transformed_configs = context
+            .eval(Source::from_bytes(
+                "deploymentHook(appName, serviceConfigs)",
+            ))
+            .map_err(|err| HooksError::InvalidDeploymentHook {
+                err: format!("Cannot execute hook: {err}"),
+            })?;
+
+        let transformed_configs = transformed_configs.to_json(&mut context).unwrap();
+
+        Self::parse_service_config(services, transformed_configs)
+    }
+
+    fn parse_hook(
+        hook_path: PathBuf,
+        hook_content: &str,
+        function_name: &str,
+    ) -> Result<Context, HooksError> {
         let mut context = Context::default();
 
         if let Err(err) = context.eval(Source::from_bytes(&hook_content)) {
@@ -103,13 +213,18 @@ impl<'a> Hooks<'a> {
                 "Cannot populate hook {:?} to Javascript context: {:?}",
                 hook_path, err
             );
-            return None;
+            return Err(HooksError::Unexpected {
+                err: err.to_string(),
+            });
         }
 
-        if context.interner().get("deploymentHook").is_some() {
-            Some(context)
+        if context.interner().get(function_name).is_some() {
+            Ok(context)
         } else {
-            None
+            Err(HooksError::ExpectedFunctionNotPresent {
+                expected: function_name.to_string(),
+                file: hook_path,
+            })
         }
     }
 
@@ -135,14 +250,16 @@ impl<'a> Hooks<'a> {
     fn parse_service_config<Iter>(
         services: Iter,
         transformed_configs: serde_json::value::Value,
-    ) -> Result<Vec<DeployableService>, AppsServiceError>
+    ) -> Result<Vec<DeployableService>, HooksError>
     where
         Iter: IntoIterator<Item = DeployableService>,
     {
         let mut transformed_configs =
             serde_json::from_value::<Vec<JsServiceConfig>>(transformed_configs).map_err(|err| {
-                error!("Cannot parse result of deployment hook: {}", err);
-                AppsServiceError::InvalidDeploymentHook
+                error!("Cannot parse result of deployment hook: {err}");
+                HooksError::InvalidDeploymentHook {
+                    err: err.to_string(),
+                }
             })?;
 
         Ok(services
@@ -234,355 +351,563 @@ impl From<&DeployableService> for JsServiceConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::apps::*;
     use crate::deployment::deployment_unit::DeploymentUnitBuilder;
     use std::collections::HashMap;
     use std::io::Write;
     use std::vec;
     use tempfile::NamedTempFile;
 
-    fn config_with_deployment_hook(script: &str) -> (NamedTempFile, Config) {
-        let mut hook_file = NamedTempFile::new().unwrap();
+    mod apply_deployment_hook {
+        use super::*;
 
-        hook_file.write_all(script.as_bytes()).unwrap();
+        fn config_with_deployment_hook(script: &str) -> (NamedTempFile, Config) {
+            let mut hook_file = NamedTempFile::new().unwrap();
 
-        let config = crate::config_from_str!(&format!(
-            r#"
+            hook_file.write_all(script.as_bytes()).unwrap();
+
+            let config = crate::config_from_str!(&format!(
+                r#"
             [hooks]
             deployment = {:?}
             "#,
-            hook_file.path()
-        ));
+                hook_file.path()
+            ));
 
-        (hook_file, config)
+            (hook_file, config)
+        }
+
+        #[tokio::test]
+        async fn with_file_modification() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        config.files['/etc/some-config.txt'] = config.name + index;
+                        return config;
+                    });
+                }
+            "#;
+
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+
+            let app_name = AppName::master();
+            let service_configs = vec![crate::sc!("service-a")];
+
+            let unit = DeploymentUnitBuilder::init(app_name, service_configs)
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_files = unit
+                .services()
+                .iter()
+                .filter_map(|service| service.files().cloned())
+                .flatten()
+                .map(|(path, content)| (path.to_str().unwrap().to_string(), content.clone()))
+                .collect::<Vec<(String, SecUtf8)>>();
+
+            assert_eq!(
+                deployed_files,
+                vec![(
+                    String::from("/etc/some-config.txt"),
+                    SecUtf8::from("service-a0")
+                )]
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn with_file_removal() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        delete config.files['/etc/some-config.txt'];
+                        return config;
+                    });
+                }
+            "#;
+
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+
+            let app_name = AppName::master();
+
+            let mut service_config = crate::sc!("service-a");
+            let mut files = BTreeMap::new();
+            files.insert(
+                PathBuf::from("/etc/some-config.txt"),
+                SecUtf8::from("value"),
+            );
+            service_config.set_files(Some(files));
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_files = unit
+                .services()
+                .iter()
+                .filter_map(|service| service.files().cloned())
+                .flatten()
+                .map(|(path, content)| (path.to_str().unwrap().to_string(), content.clone()))
+                .collect::<Vec<(String, SecUtf8)>>();
+
+            assert_eq!(deployed_files, vec![]);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn add_env() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        config.env['VARIABLE_X'] = config.name + index;
+                        return config;
+                    });
+                }
+            "#;
+
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+            let service_config = crate::sc!("service-a");
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_variables = unit
+                .services()
+                .iter()
+                .filter_map(|service| service.env().cloned())
+                .flat_map(|env| env.into_iter())
+                .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
+                .collect::<Vec<(String, String)>>();
+
+            assert_eq!(
+                deployed_variables,
+                vec![(String::from("VARIABLE_X"), String::from("service-a0"))]
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn with_env_modification() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        config.env['VARIABLE_Y'] = config.name + index;
+                        return config;
+                    });
+                }
+            "#;
+
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+
+            let mut service_config = crate::sc!("service-a");
+            service_config.set_env(Some(Environment::new(vec![EnvironmentVariable::new(
+                String::from("VARIABLE_X"),
+                SecUtf8::from("Hello"),
+            )])));
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_variables = unit
+                .services()
+                .iter()
+                .filter_map(|service| service.env().cloned())
+                .flat_map(|env| env.into_iter())
+                .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
+                .collect::<Vec<(String, String)>>();
+
+            assert_eq!(
+                deployed_variables,
+                vec![
+                    (String::from("VARIABLE_X"), String::from("Hello")),
+                    (String::from("VARIABLE_Y"), String::from("service-a0"))
+                ]
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn with_env_removal() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        delete config.env['VARIABLE_X'];
+                        return config;
+                    });
+                }
+            "#;
+
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+
+            let app_name = AppName::master();
+            let mut service_config = crate::sc!("service-a");
+            service_config.set_env(Some(Environment::new(vec![EnvironmentVariable::new(
+                String::from("VARIABLE_X"),
+                SecUtf8::from("Hello"),
+            )])));
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_variables = unit
+                .services()
+                .iter()
+                .filter_map(|service| service.env().cloned())
+                .flat_map(|env| env.into_iter())
+                .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
+                .collect::<Vec<(String, String)>>();
+
+            assert_eq!(deployed_variables, vec![]);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn without_adding_additional_services() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    configs.push({
+                        name: 'hello',
+                        image: 'hello-world',
+                        type: 'instance'
+                    });
+                    return configs;
+                }
+            "#;
+            let service_config = crate::sc!("service-a");
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_services = unit
+                .services()
+                .iter()
+                .map(|services| services.service_name().clone())
+                .collect::<Vec<_>>();
+
+            assert_eq!(deployed_services, vec![String::from("service-a")]);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn fail_when_modifying_immutable_values() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return configs.map((config, index) => {
+                        config.name = config.name + index;
+                        return config;
+                    });
+                }
+            "#;
+
+            let service_config = crate::sc!("service-a");
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+
+            let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await?
+                .build();
+
+            let deployed_services = unit.services();
+
+            assert!(deployed_services.is_empty());
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn fail_with_undefined_var_usage() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return undefinedVar + appName
+                }
+            "#;
+
+            let service_config = crate::sc!("service-a");
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+            let result = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await;
+
+            assert!(
+                matches!(result, Err(HooksError::InvalidDeploymentHook { err }) if err == "Cannot execute hook: ReferenceError: undefinedVar is not defined")
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn fail_with_hook_returning_invalid_object() -> anyhow::Result<()> {
+            let script = r#"
+                function deploymentHook( appName, configs ) {
+                    return 'unexpected return value';
+                }
+            "#;
+
+            let service_config = crate::sc!("service-a");
+            let (_temp_js_file, config) = config_with_deployment_hook(script);
+            let app_name = AppName::master();
+            let result = DeploymentUnitBuilder::init(app_name, vec![service_config])
+                .extend_with_config(&config)
+                .extend_with_templating_only_service_configs(Vec::new())
+                .extend_with_image_infos(HashMap::new())
+                .without_owners()
+                .apply_templating(&None, None)?
+                .apply_hooks(&config)
+                .await;
+
+            assert!(
+                matches!(result, Err(HooksError::InvalidDeploymentHook { err }) if err == "invalid type: string \"unexpected return value\", expected a sequence")
+            );
+
+            Ok(())
+        }
     }
 
-    #[tokio::test]
-    async fn apply_deployment_hook_with_file_modification() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                config.files['/etc/some-config.txt'] = config.name + index;
-                return config;
-            });
-        }
-        "#;
+    mod apply_id_token_claims_to_owner_hook {
+        use crate::auth::AdditionalClaims;
 
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-
-        let app_name = AppName::master();
-        let service_configs = vec![crate::sc!("service-a")];
-
-        let unit = DeploymentUnitBuilder::init(app_name, service_configs)
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_files = unit
-            .services()
-            .iter()
-            .filter_map(|service| service.files().cloned())
-            .flatten()
-            .map(|(path, content)| (path.to_str().unwrap().to_string(), content.clone()))
-            .collect::<Vec<(String, SecUtf8)>>();
-
-        assert_eq!(
-            deployed_files,
-            vec![(
-                String::from("/etc/some-config.txt"),
-                SecUtf8::from("service-a0")
-            )]
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn apply_deployment_hook_with_file_removal() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                delete config.files['/etc/some-config.txt'];
-                return config;
-            });
-        }
-        "#;
-
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-
-        let app_name = AppName::master();
-
-        let mut service_config = crate::sc!("service-a");
-        let mut files = BTreeMap::new();
-        files.insert(
-            PathBuf::from("/etc/some-config.txt"),
-            SecUtf8::from("value"),
-        );
-        service_config.set_files(Some(files));
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_files = unit
-            .services()
-            .iter()
-            .filter_map(|service| service.files().cloned())
-            .flatten()
-            .map(|(path, content)| (path.to_str().unwrap().to_string(), content.clone()))
-            .collect::<Vec<(String, SecUtf8)>>();
-
-        assert_eq!(deployed_files, vec![]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn apply_deployment_hook_add_env() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                config.env['VARIABLE_X'] = config.name + index;
-                return config;
-            });
-        }
-        "#;
-
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-        let app_name = AppName::master();
-        let service_config = crate::sc!("service-a");
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_variables = unit
-            .services()
-            .iter()
-            .filter_map(|service| service.env().cloned())
-            .flat_map(|env| env.into_iter())
-            .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
-            .collect::<Vec<(String, String)>>();
-
-        assert_eq!(
-            deployed_variables,
-            vec![(String::from("VARIABLE_X"), String::from("service-a0"))]
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn apply_deployment_hook_with_env_modification() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                config.env['VARIABLE_Y'] = config.name + index;
-                return config;
-            });
-        }
-        "#;
-
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-        let app_name = AppName::master();
-
-        let mut service_config = crate::sc!("service-a");
-        service_config.set_env(Some(Environment::new(vec![EnvironmentVariable::new(
-            String::from("VARIABLE_X"),
-            SecUtf8::from("Hello"),
-        )])));
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_variables = unit
-            .services()
-            .iter()
-            .filter_map(|service| service.env().cloned())
-            .flat_map(|env| env.into_iter())
-            .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
-            .collect::<Vec<(String, String)>>();
-
-        assert_eq!(
-            deployed_variables,
-            vec![
-                (String::from("VARIABLE_X"), String::from("Hello")),
-                (String::from("VARIABLE_Y"), String::from("service-a0"))
-            ]
-        );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn apply_deployment_hook_with_env_removal() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                delete config.env['VARIABLE_X'];
-                return config;
-            });
-        }
-        "#;
-
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-
-        let app_name = AppName::master();
-        let mut service_config = crate::sc!("service-a");
-        service_config.set_env(Some(Environment::new(vec![EnvironmentVariable::new(
-            String::from("VARIABLE_X"),
-            SecUtf8::from("Hello"),
-        )])));
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_variables = unit
-            .services()
-            .iter()
-            .filter_map(|service| service.env().cloned())
-            .flat_map(|env| env.into_iter())
-            .map(|env| (env.key().clone(), env.value().unsecure().to_string()))
-            .collect::<Vec<(String, String)>>();
-
-        assert_eq!(deployed_variables, vec![]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn apply_deployment_hook_without_adding_additional_services() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            configs.push({
-                name: 'hello',
-                image: 'hello-world',
-                type: 'instance'
-            });
-            return configs;
-        }
-        "#;
-        let service_config = crate::sc!("service-a");
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-        let app_name = AppName::master();
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_services = unit
-            .services()
-            .iter()
-            .map(|services| services.service_name().clone())
-            .collect::<Vec<_>>();
-
-        assert_eq!(deployed_services, vec![String::from("service-a")]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn do_not_apply_deployment_hook_when_modifying_immutable_values() -> Result<(), AppsError>
-    {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return configs.map((config, index) => {
-                config.name = config.name + index;
-                return config;
-            });
-        }
-        "#;
-
-        let service_config = crate::sc!("service-a");
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-        let app_name = AppName::master();
-
-        let unit = DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await?
-            .build();
-
-        let deployed_services = unit.services();
-
-        assert!(deployed_services.is_empty());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn fail_with_hook_returning_invalid_object() -> Result<(), AppsError> {
-        let script = r#"
-        function deploymentHook( appName, configs ) {
-            return 'unexpected return value';
-        }
-        "#;
-        let mut deployed_services_error = String::new();
-        let service_config = crate::sc!("service-a");
-        let (_temp_js_file, config) = config_with_deployment_hook(script);
-        let app_name = AppName::master();
-        match DeploymentUnitBuilder::init(app_name, vec![service_config])
-            .extend_with_config(&config)
-            .extend_with_templating_only_service_configs(Vec::new())
-            .extend_with_image_infos(HashMap::new())
-            .without_owners()
-            .apply_templating(&None, None)?
-            .apply_hooks(&config)
-            .await
-        {
-            Ok(no_error) => Some(no_error),
-            Err(err) => {
-                deployed_services_error = err.to_string();
-                None
-            }
+        use super::*;
+        use openidconnect::{
+            EndUserName, IdTokenClaims, IssuerUrl, LocalizedClaim, StandardClaims,
+            SubjectIdentifier,
         };
 
-        assert_eq!(
-            deployed_services_error,
-            String::from("Invalid deployment hook.")
-        );
+        #[tokio::test]
+        async fn fail_with_none_existing_file() {
+            let config = crate::config_from_str!(&format!(
+                r#"
+                [hooks]
+                idTokenClaimsToOwner = "/path/does/not/exists"
+                "#,
+            ));
+            let hook = Hooks::new(&config);
 
-        Ok(())
+            let result = hook
+                .apply_id_token_claims_to_owner_hook(User::Oidc {
+                    id_token_claims: IdTokenClaims::new(
+                        IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                        Vec::new(),
+                        chrono::Utc::now(),
+                        chrono::Utc::now(),
+                        StandardClaims::new(SubjectIdentifier::new(String::from("github-user"))),
+                        AdditionalClaims::empty(),
+                    ),
+                })
+                .await;
+
+            assert_eq!(
+                result,
+                Err(HooksError::UserToOwner {
+                    err: String::from("Cannot read hook file \"/path/does/not/exists\": No such file or directory (os error 2)")
+                })
+            )
+        }
+
+        fn config_with_claims_to_owner_hook(
+            script: Option<&str>,
+        ) -> (Option<NamedTempFile>, Config) {
+            let Some(script) = script else {
+                return (None, Config::default());
+            };
+
+            let mut hook_file = NamedTempFile::new().unwrap();
+
+            hook_file.write_all(script.as_bytes()).unwrap();
+
+            let config = crate::config_from_str!(&format!(
+                r#"
+                [hooks]
+                idTokenClaimsToOwner = {:?}
+                "#,
+                hook_file.path()
+            ));
+
+            (Some(hook_file), config)
+        }
+
+        #[tokio::test]
+        async fn for_anonymous_without_hook() -> anyhow::Result<()> {
+            let (_temp_js_file, config) = config_with_claims_to_owner_hook(None);
+            let hook = Hooks::new(&config);
+
+            let owner = hook
+                .apply_id_token_claims_to_owner_hook(User::Anonymous)
+                .await?;
+
+            assert_eq!(owner, None);
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn for_oidc_without_hook() -> anyhow::Result<()> {
+            let (_temp_js_file, config) = config_with_claims_to_owner_hook(None);
+            let hook = Hooks::new(&config);
+
+            let owner = hook
+                .apply_id_token_claims_to_owner_hook(User::Oidc {
+                    id_token_claims: IdTokenClaims::new(
+                        IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                        Vec::new(),
+                        chrono::Utc::now(),
+                        chrono::Utc::now(),
+                        StandardClaims::new(SubjectIdentifier::new(String::from("github-user"))),
+                        AdditionalClaims::empty(),
+                    ),
+                })
+                .await?;
+
+            assert_eq!(
+                owner,
+                Some(Owner {
+                    sub: SubjectIdentifier::new(String::from("github-user")),
+                    iss: IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                    name: None
+                })
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn for_oidc_with_hook() -> anyhow::Result<()> {
+            let (_temp_js_file, config) = config_with_claims_to_owner_hook(Some(
+                r#"
+                function idTokenClaimsToOwnerHook(claims) {
+                   return {
+                      sub: claims.user_id ? claims.user_id : claims.sub,
+                      iss: claims.iss,
+                      name: claims.user_name ? claims.user_name : claims.name,
+                   };
+                }
+                "#,
+            ));
+            let hook = Hooks::new(&config);
+
+            let mut name = LocalizedClaim::new();
+            name.insert(None, EndUserName::new(String::from("Some Person")));
+            let owner = hook
+                .apply_id_token_claims_to_owner_hook(User::Oidc {
+                    id_token_claims: IdTokenClaims::new(
+                        IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                        Vec::new(),
+                        chrono::Utc::now(),
+                        chrono::Utc::now(),
+                        StandardClaims::new(SubjectIdentifier::new(String::from("github-user")))
+                            .set_name(Some(name)),
+                        AdditionalClaims::with_claims(serde_json::json!({ "user_id": "user-id" })),
+                    ),
+                })
+                .await?;
+
+            assert_eq!(
+                owner,
+                Some(Owner {
+                    sub: SubjectIdentifier::new(String::from("user-id")),
+                    iss: IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                    name: Some(String::from("Some Person")),
+                })
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn fail_gracefully_if_script_is_malformed() {
+            let (_temp_js_file, config) = config_with_claims_to_owner_hook(Some(
+                r#"
+                function idTokenClaimsToOwnerHook(claims) {
+                   return undefinedVar + claims.sub;
+                }
+                "#,
+            ));
+            let hook = Hooks::new(&config);
+
+            let mut name = LocalizedClaim::new();
+            name.insert(None, EndUserName::new(String::from("Some Person")));
+            let result = hook
+                .apply_id_token_claims_to_owner_hook(User::Oidc {
+                    id_token_claims: IdTokenClaims::new(
+                        IssuerUrl::new(String::from("https://github.com")).unwrap(),
+                        Vec::new(),
+                        chrono::Utc::now(),
+                        chrono::Utc::now(),
+                        StandardClaims::new(SubjectIdentifier::new(String::from("github-user")))
+                            .set_name(Some(name)),
+                        AdditionalClaims::with_claims(serde_json::json!({ "user_id": "user-id" })),
+                    ),
+                })
+                .await;
+
+            assert_eq!(
+                result,
+                Err(HooksError::UserToOwner {
+                    err: String::from(
+                        "Cannot execute hook: ReferenceError: undefinedVar is not defined"
+                    )
+                })
+            )
+        }
     }
 }

--- a/api/src/models/app_name.rs
+++ b/api/src/models/app_name.rs
@@ -40,6 +40,10 @@ impl AppName {
     pub fn master() -> Self {
         Self(String::from("master"))
     }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
 }
 
 impl serde::Serialize for AppName {
@@ -124,7 +128,7 @@ pub enum AppNameError {
 impl From<Utf8Error> for AppNameError {
     fn from(err: Utf8Error) -> Self {
         AppNameError::InvalidUrlDecodedParam {
-            err: format!("{}", err),
+            err: format!("{err}"),
         }
     }
 }
@@ -132,7 +136,7 @@ impl From<Utf8Error> for AppNameError {
 impl From<AppNameError> for HttpApiError {
     fn from(err: AppNameError) -> Self {
         HttpApiProblem::with_title_and_type(StatusCode::BAD_REQUEST)
-            .detail(format!("{}", err))
+            .detail(format!("{err}"))
             .into()
     }
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -31,9 +31,8 @@ export ROCKET_SECRET_KEY=$(openssl rand -base64 32)
 To interact with the PREvant REST API with authentication one can send an HTTP
 request with an `Authorization` header (see example below). The header must
 contain the ID token and can be retrieve usually from the OpenID provider. For
-example, it can be injected into [GitLab
-CI](https://docs.gitlab.com/ci/yaml/#id_tokens) or can be [retrieved form
-Keycloak](https://stackoverflow.com/a/77880906/5088458).
+example, it can be injected into [GitLab CI][GitLab CI ID Token] or can be
+[retrieved form Keycloak](https://stackoverflow.com/a/77880906/5088458).
 
 ```bash
 export JWT_ID_TOKEN="…get the token from a secure place…"
@@ -43,9 +42,40 @@ echo { "header=\"Authorization: Bearer ${JWT_ID_TOKEN}\""} \
    curl --config - -X DELETE https://prevant.local/apps/app_name
 ```
 
+## Mapping ID Token Claims to Owners
+
+In some situations the ID token, used for authenticating the request, is
+generated on behalf of someone and thus, the `sub` claim doesn't match to the
+user's `sub` claim on the PREvant dashboard. For example, [GitLab CI ID
+tokens][GitLab CI ID Token] can contain the `user_id` but not in the `sub`
+field.
+
+In order to be able to have this mapping aligned, there is a hook that allows
+transforming the ID token claims to the corrected owner. First, create a
+Javascript file that will be mounted into the PREvant container. For example,
+like this:
+
+```javascript
+function idTokenClaimsToOwnerHook(claims) {
+   return {
+      sub: claims.user_id ? claims.user_id : claims.sub,
+      iss: claims.iss,
+      name: claims.user_name ? claims.user_name : claims.name,
+   };
+}
+```
+Then, make sure that this file is configured as [hook](hooks.md):
+
+```toml
+[hooks]
+idTokenClaimsToOwner = "/path/to/file.js"
+```
+
+
 [OpenID]: https://openid.net/
 [Rocket-Cookie-Encryption]: https://api.rocket.rs/v0.5/rocket/http/struct.CookieJar#encryption-key
 [Azure]: https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc
 [Google]: https://developers.google.com/identity/openid-connect/openid-connect
 [GitLab]: https://docs.gitlab.com/integration/openid_connect_provider/
+[GitLab CI ID Token]: https://docs.gitlab.com/ci/yaml/#id_tokens
 [Keycloak]: https://www.keycloak.org/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,3 @@
-
-Note: The image `aixigo/prevant` provides the REST-API in order to deploy containers and to compose them into reviewable application.
-
 # Configuration and Customization
 
 Users can customize PREvant's operations by adjusting settings in a
@@ -13,7 +10,7 @@ variable, and from some CLI options.
 
 ## Authentication
 
-See [authentication.md] how to configure authentication (highly recommended).
+See [authentication.md](authentication.md) how to configure authentication (highly recommended).
 
 ## Runtime Configuration
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,8 +1,21 @@
-## Hooks
+# Hooks
 
-Hooks can be used to manipulate the deployment before handing it over to actual infrastructure and they are able to manipulate all service configurations once for any deployment REST API call. For example, based on the deployment's app name you can decide to reconfigure your services to use a different DBMS so that you are able to verify that your services work with different DBMSs.
+Note: the hook's Javascript engine is based on
+[Boa](https://github.com/boa-dev/boa) and this engine does not implement all
+ECMAScript features yet.
 
-Technically, hooks are Javascript files that provide functions to modify all service configurations of a deployment. For example, add following section to your PREvant configuration. This configuration snippet enables the _deployemnt hook_ that will be used to modify the services' configurations.
+## Deployment
+
+Hooks can be used to manipulate the deployment before handing it over to actual
+infrastructure and they are able to manipulate all service configurations once
+for any deployment REST API call. For example, based on the deployment's app
+name you can decide to reconfigure your services to use a different DBMS so
+that you are able to verify that your services work with different DBMSs.
+
+Technically, hooks are Javascript files that provide functions to modify all
+service configurations of a deployment. For example, add following section to
+your PREvant configuration. This configuration snippet enables the _deployemnt
+hook_ that will be used to modify the services' configurations.
 
 ```toml
 [hooks]
@@ -17,11 +30,13 @@ function deploymentHook(appName, serviceConfigs) {
 }
 ```
 
-Note: the templating has been already applied and the hook has only access to the final value and it cannot modify the original values.
+Note: the templating has been already applied and the hook has only access to
+the final value and it cannot modify the original values.
 
-Note: the hook's Javascript engine is based on [Boa](https://github.com/boa-dev/boa) and this engine does not implement all ECMAScript features yet.
-
-PREvant calls this function with the app name (see `appName`) and an array of service configurations (see `serviceConfigs`). This array can be modified and must be returned by the function. The elements in the array are object with following fields:
+PREvant calls this function with the app name (see `appName`) and an array of
+service configurations (see `serviceConfigs`). This array can be modified and
+must be returned by the function. The elements in the array are object with
+following fields:
 
 | Key           | Description                                                                                                |
 |---------------|------------------------------------------------------------------------------------------------------------|
@@ -30,3 +45,38 @@ PREvant calls this function with the app name (see `appName`) and an array of se
 | `type`        | The type of the service, e.g. `instance`, `replica`, etc. (readonly).                                      |
 | `env`         | A map of key and value containing the environment variables that will be used when creating the container. |
 | `files`       | A map of key and value containing the files that will be mounted into the container.                       |
+
+## ID Token Claims to Owner Mapping
+
+```toml
+[hooks]
+idTokenClaimsToOwner = 'path/to/hook.js'
+```
+
+The hook at `path/to/hook.js` must provide following Javascript function:
+
+```javascript
+function idTokenClaimsToOwnerHook(claims) {
+   return {
+      sub: claims.user_id ? claims.user_id : claims.sub,
+      iss: claims.iss,
+      name: claims.user_name ? claims.user_name : claims.name,
+   };
+}
+```
+
+PREvant calls this function with the [ID token claims] (see parameter `claims`)
+as first argument, serialized as the JWT payload, and it expects a return value
+of the following form:
+
+```typescript
+interface Owner {
+   // sub & iss will be compared against the ID token claims of the user logged
+   // in at the dashboard.
+   sub: string,
+   iss: string,
+   name?: string,
+}
+```
+
+[ID token claims]: https://auth0.com/docs/secure/tokens/id-tokens/id-token-structure


### PR DESCRIPTION
In some situations the ID token, used by authentication, is generated on behalf of someone and thus, the sub field doesn't match to the user's sub field on the PREvant dashboard. For example, in GitLab CI tokens can contain the user_id but not in the sub field.

In order to be able to have this mapping, there is a new hook that allows transforming the ID token claims to the corrected owner.