### PR TITLE
InMemory Worker Producer Queue

### DIFF
--- a/api/res/openapi.yml
+++ b/api/res/openapi.yml
@@ -167,12 +167,6 @@ paths:
               schema:
                 type: string
                 format: url
-        '409':
-          description: The application is currently in deployment. A parallel deployment of two apps is not allowed.
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/ProblemDetails'
         '500':
           description: Server error
           content:
@@ -297,10 +291,12 @@ paths:
       description: >-
         Can be used to poll the completion of a status change, such as deploying or stopping an app.
       responses:
+        '200':
+          description: The result of the status change.
         '202':
           description: The status change is still running
         '404':
-          description: The status change finished
+          description: The status change finished and has been cleaned up.
   /webhooks/:
     post:
       summary: Cleans up apps when webhook triggers this resource.

--- a/api/src/apps/queue.rs
+++ b/api/src/apps/queue.rs
@@ -1,0 +1,355 @@
+use super::{AppsService, AppsServiceError};
+use crate::{
+    auth::User,
+    models::{App, AppName, AppStatusChangeId, ServiceConfig},
+};
+use anyhow::Result;
+use chrono::{DateTime, TimeDelta, Utc};
+use rocket::{
+    fairing::{Fairing, Info, Kind},
+    Build, Orbit, Rocket,
+};
+use std::{collections::VecDeque, future::Future, sync::Arc, time::Duration};
+use tokio::{
+    sync::{Mutex, Notify},
+    time::{sleep, sleep_until, timeout},
+};
+
+pub struct AppProcessingQueue {}
+
+impl AppProcessingQueue {
+    pub fn fairing() -> Self {
+        Self {}
+    }
+}
+
+#[rocket::async_trait]
+impl Fairing for AppProcessingQueue {
+    fn info(&self) -> Info {
+        Info {
+            name: "app-queue",
+            kind: Kind::Ignite | Kind::Liftoff,
+        }
+    }
+
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> rocket::fairing::Result {
+        let producer = AppTaskQueueProducer {
+            db: Arc::new(AppTaskQueueDB::inmemory()),
+            notify: Arc::new(Notify::new()),
+        };
+
+        Ok(rocket.manage(producer))
+    }
+
+    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
+        let apps = rocket.state::<Arc<AppsService>>().unwrap().clone();
+        let producer = rocket.state::<AppTaskQueueProducer>().unwrap();
+        let consumer = AppTaskQueueConsumer {
+            db: producer.db.clone(),
+            notify: producer.notify.clone(),
+        };
+        let mut shutdown = rocket.shutdown();
+
+        rocket::tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    res = consumer.process_next_task(&apps) => {
+                        if let Err(err) = res {
+                            log::error!("Cannot process task: {err}");
+                        }
+                    }
+                    _ = &mut shutdown => {
+                        log::info!("Shutting down queue processing");
+                        break;
+                    }
+                };
+
+                match consumer.clean_up_done_tasks().await {
+                    Ok(number_of_deleted_tasks) if number_of_deleted_tasks > 0 => {
+                        log::debug!("Deleted {number_of_deleted_tasks} done tasks");
+                    }
+                    Err(err) => {
+                        log::error!("Cannot cleanup done task: {err}");
+                    }
+                    _ => {}
+                }
+            }
+        });
+    }
+}
+
+pub struct AppTaskQueueProducer {
+    db: Arc<AppTaskQueueDB>,
+    notify: Arc<Notify>,
+}
+impl AppTaskQueueProducer {
+    pub async fn enqueue_create_or_update_task(
+        &self,
+        app_name: AppName,
+        replicate_from: Option<AppName>,
+        service_configs: Vec<ServiceConfig>,
+        user: User,
+        user_defined_parameters: Option<serde_json::Value>,
+    ) -> Result<AppStatusChangeId> {
+        let status_id = AppStatusChangeId::new();
+        self.db
+            .enqueue_task(AppTask::CreateOrUpdate {
+                app_name,
+                status_id,
+                replicate_from,
+                service_configs,
+                user,
+                user_defined_parameters,
+            })
+            .await?;
+
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!("Notify about new create or update task: {status_id}.");
+        }
+        self.notify.notify_one();
+
+        Ok(status_id)
+    }
+
+    pub async fn enqueue_delete_task(&self, app_name: AppName) -> Result<AppStatusChangeId> {
+        let status_id = AppStatusChangeId::new();
+        self.db
+            .enqueue_task(AppTask::Delete {
+                app_name,
+                status_id,
+            })
+            .await?;
+
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!("Notify about new delete task: {status_id}.");
+        }
+        self.notify.notify_one();
+
+        Ok(status_id)
+    }
+
+    pub async fn try_wait_for_task(
+        &self,
+        status_id: &AppStatusChangeId,
+        wait_timeout: Duration,
+    ) -> Option<std::result::Result<App, AppsServiceError>> {
+        let interval = Duration::from_secs(2);
+
+        let mut interval_timer = tokio::time::interval(interval);
+        let start_time = tokio::time::Instant::now();
+
+        loop {
+            tokio::select! {
+                _ = interval_timer.tick() => {
+                    match timeout(wait_timeout, self.db.peek_result(status_id)).await {
+                        Ok(Some(result)) => return Some(result),
+                        // TODO: correct so far?
+                        Ok(None) => continue,
+                        Err(_) => todo!()
+                    }
+                }
+                _ = sleep_until(start_time + wait_timeout) => {
+                    log::debug!("Timeout reached, stopping querying the queue");
+                    break;
+                }
+            }
+        }
+
+        None
+    }
+}
+
+struct AppTaskQueueConsumer {
+    db: Arc<AppTaskQueueDB>,
+    notify: Arc<Notify>,
+}
+
+impl AppTaskQueueConsumer {
+    pub async fn process_next_task(&self, apps: &AppsService) -> Result<()> {
+        tokio::select! {
+            _ = self.notify.notified() => {
+                log::debug!("Got notified by another thread to check for new items in the queue.");
+            }
+            _ = sleep(Duration::from_secs(30)) => {
+                log::debug!("Regular task check.");
+            }
+        }
+
+        self.db
+            .execute_task(async |task| {
+                if log::log_enabled!(log::Level::Debug) {
+                    log::debug!(
+                        "Processing task {} for {}.",
+                        task.status_id(),
+                        task.app_name()
+                    );
+                }
+                match task {
+                    AppTask::CreateOrUpdate {
+                        app_name,
+                        replicate_from,
+                        service_configs,
+                        user,
+                        user_defined_parameters,
+                        ..
+                    } => {
+                        if log::log_enabled!(log::Level::Debug) {
+                            log::debug!("Creating or updating app {app_name}.");
+                        }
+                        apps.create_or_update(
+                            &app_name,
+                            replicate_from,
+                            &service_configs,
+                            user,
+                            user_defined_parameters,
+                        )
+                        .await
+                    }
+                    AppTask::Delete { app_name, .. } => {
+                        if log::log_enabled!(log::Level::Debug) {
+                            log::debug!("Deleting app {app_name}.");
+                        }
+                        apps.delete_app(&app_name).await
+                    }
+                }
+            })
+            .await
+    }
+
+    pub async fn clean_up_done_tasks(&self) -> Result<usize> {
+        let an_hour_ago = Utc::now() - TimeDelta::hours(1);
+        self.db.clean_up_done_tasks(an_hour_ago).await
+    }
+}
+
+#[derive(Clone)]
+enum AppTask {
+    CreateOrUpdate {
+        app_name: AppName,
+        status_id: AppStatusChangeId,
+        replicate_from: Option<AppName>,
+        service_configs: Vec<ServiceConfig>,
+        user: User,
+        user_defined_parameters: Option<serde_json::Value>,
+    },
+    Delete {
+        status_id: AppStatusChangeId,
+        app_name: AppName,
+    },
+}
+impl AppTask {
+    fn app_name(&self) -> &AppName {
+        match self {
+            AppTask::CreateOrUpdate { app_name, .. } => app_name,
+            AppTask::Delete { app_name, .. } => app_name,
+        }
+    }
+    fn status_id(&self) -> &AppStatusChangeId {
+        match self {
+            AppTask::CreateOrUpdate { status_id, .. } => status_id,
+            AppTask::Delete { status_id, .. } => status_id,
+        }
+    }
+}
+pub enum AppTaskStatus {
+    New,
+    InProcess,
+    Done((DateTime<Utc>, std::result::Result<App, AppsServiceError>)),
+}
+
+enum AppTaskQueueDB {
+    InMemory(Mutex<VecDeque<(AppTask, AppTaskStatus)>>),
+}
+
+impl AppTaskQueueDB {
+    fn inmemory() -> Self {
+        Self::InMemory(Mutex::new(VecDeque::new()))
+    }
+
+    pub async fn enqueue_task(&self, task: AppTask) -> Result<()> {
+        match self {
+            AppTaskQueueDB::InMemory(mutex) => {
+                let mut queue = mutex.lock().await;
+                queue.push_back((task, AppTaskStatus::New));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn peek_result(
+        &self,
+        status_id: &AppStatusChangeId,
+    ) -> Option<std::result::Result<App, AppsServiceError>> {
+        log::debug!("Checking for results for {status_id}.");
+        match self {
+            AppTaskQueueDB::InMemory(mutex) => {
+                let queue = mutex.lock().await;
+
+                for (task, status) in queue.iter() {
+                    if task.status_id() == status_id {
+                        if let AppTaskStatus::Done((_, result)) = status {
+                            return Some(result.clone());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    async fn execute_task<F, Fut>(&self, f: F) -> Result<()>
+    where
+        F: FnOnce(AppTask) -> Fut,
+        Fut: Future<Output = std::result::Result<App, AppsServiceError>>,
+    {
+        match self {
+            AppTaskQueueDB::InMemory(mutex) => {
+                let task = {
+                    let mut queue = mutex.lock().await;
+
+                    let Some(task) = queue
+                        .iter_mut()
+                        .find(|(_, s)| matches!(s, AppTaskStatus::New))
+                    else {
+                        return Ok(());
+                    };
+
+                    task.1 = AppTaskStatus::InProcess;
+
+                    task.0.clone()
+                };
+
+                let status_id = *task.status_id();
+                let result = f(task).await;
+
+                let mut queue = mutex.lock().await;
+                let Some(task) = queue
+                    .iter_mut()
+                    .find(|(task, _)| task.status_id() == &status_id)
+                else {
+                    anyhow::bail!("Cannot update {status_id} in queue which should be present");
+                };
+
+                task.1 = AppTaskStatus::Done((Utc::now(), result));
+            }
+        };
+
+        Ok(())
+    }
+
+    async fn clean_up_done_tasks(&self, older_than: DateTime<Utc>) -> Result<usize> {
+        match self {
+            AppTaskQueueDB::InMemory(mutex) => {
+                let mut queue = mutex.lock().await;
+
+                let before = queue.len();
+                queue.retain(
+                    |(_, status)| !matches!(status, AppTaskStatus::Done((timestamp, _)) if timestamp < &older_than),
+                );
+
+                Ok(before - queue.len())
+            }
+        }
+    }
+}

--- a/api/src/apps/routes/logs.rs
+++ b/api/src/apps/routes/logs.rs
@@ -200,9 +200,7 @@ impl<'r> FromRequest<'r> for AcceptingPlainText {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        apps::HostMetaCache, config::Config, infrastructure::Dummy, models::AppStatusChangeId, sc,
-    };
+    use crate::{apps::HostMetaCache, config::Config, infrastructure::Dummy, sc};
     use rocket::{
         http::{hyper::header::CONTENT_TYPE, Accept, Header},
         local::asynchronous::Client,
@@ -217,7 +215,6 @@ mod test {
         let _result = apps
             .create_or_update(
                 &AppName::master(),
-                &AppStatusChangeId::new(),
                 None,
                 &vec![sc!("service-a")],
                 crate::auth::User::Anonymous,

--- a/api/src/auth/user.rs
+++ b/api/src/auth/user.rs
@@ -1,6 +1,7 @@
 use openidconnect::{core::CoreGenderClaim, IdTokenClaims};
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone)]
 pub enum User {
     Anonymous,
     Oidc {

--- a/api/src/infrastructure/dummy_infrastructure.rs
+++ b/api/src/infrastructure/dummy_infrastructure.rs
@@ -137,7 +137,6 @@ impl Infrastructure for DummyInfrastructure {
 
     async fn deploy_services(
         &self,
-        _status_id: &str,
         deployment_unit: &DeploymentUnit,
         _container_config: &ContainerConfig,
     ) -> Result<App> {
@@ -175,7 +174,7 @@ impl Infrastructure for DummyInfrastructure {
         Ok(self.fetch_apps().await?.remove(app_name).unwrap())
     }
 
-    async fn stop_services(&self, _status_id: &str, app_name: &AppName) -> Result<App> {
+    async fn stop_services(&self, app_name: &AppName) -> Result<App> {
         self.delay_if_configured().await;
 
         let mut services = self.services.lock().unwrap();

--- a/api/src/infrastructure/infrastructure.rs
+++ b/api/src/infrastructure/infrastructure.rs
@@ -56,20 +56,15 @@ pub trait Infrastructure: Send + Sync + DynClone {
     ///   must be able to find the corresponding services.
     async fn deploy_services(
         &self,
-        status_id: &str,
         deployment_unit: &DeploymentUnit,
         container_config: &ContainerConfig,
     ) -> Result<App>;
-
-    async fn get_status_change(&self, _status_id: &str) -> Result<Option<App>> {
-        Ok(None)
-    }
 
     /// Stops the services running for the given `app_name`
     ///
     /// The implementation must ensure that it returns the services that have been
     /// stopped.
-    async fn stop_services(&self, status_id: &str, app_name: &AppName) -> Result<App>;
+    async fn stop_services(&self, app_name: &AppName) -> Result<App>;
 
     /// Streams the log lines with a the corresponding timestamps in it.
     async fn get_logs<'a>(

--- a/api/src/infrastructure/kubernetes/infrastructure.rs
+++ b/api/src/infrastructure/kubernetes/infrastructure.rs
@@ -202,7 +202,7 @@ impl KubernetesInfrastructure {
                 Ok(())
             }
             Err(KubeError::Api(ErrorResponse { code: 409, .. })) => {
-                debug!("Namespace {} already exists.", app_name);
+                debug!("Namespace {app_name} already exists.");
 
                 let annotations = namespace_annotations(
                     &self.config,
@@ -210,10 +210,7 @@ impl KubernetesInfrastructure {
                     deployment_unit.owners(),
                 );
                 if annotations.is_some() {
-                    debug!(
-                        "Patching namespace {} with user defined parameters.",
-                        app_name
-                    );
+                    debug!("Patching namespace {app_name} with user defined parameters.");
                     api.patch(
                         &app_name.to_rfc1123_namespace_id(),
                         &PatchParams::apply("PREvant"),
@@ -231,7 +228,7 @@ impl KubernetesInfrastructure {
                 Ok(())
             }
             Err(e) => {
-                error!("Cannot deploy namespace: {}", e);
+                error!("Cannot deploy namespace: {e}");
                 Err(e.into())
             }
         }
@@ -357,7 +354,7 @@ impl KubernetesInfrastructure {
                         persistent_volume_map.insert(declared_volume, pvc);
                     }
                     Err(e) => {
-                        error!("Cannot deploy persistent volume claim: {}", e);
+                        error!("Cannot deploy persistent volume claim: {e}");
                         return Err(e.into());
                     }
                 }
@@ -511,7 +508,7 @@ impl Infrastructure for KubernetesInfrastructure {
             let service = match Service::try_from((deployment, pod)) {
                 Ok(service) => service,
                 Err(e) => {
-                    debug!("Deployment does not provide required data: {:?}", e);
+                    debug!("Deployment does not provide required data: {e:?}");
                     continue;
                 }
             };
@@ -559,7 +556,6 @@ impl Infrastructure for KubernetesInfrastructure {
 
     async fn deploy_services(
         &self,
-        _status_id: &str,
         deployment_unit: &DeploymentUnit,
         container_config: &ContainerConfig,
     ) -> Result<App> {
@@ -636,7 +632,7 @@ impl Infrastructure for KubernetesInfrastructure {
         ))
     }
 
-    async fn stop_services(&self, _status_id: &str, app_name: &AppName) -> Result<App> {
+    async fn stop_services(&self, app_name: &AppName) -> Result<App> {
         let Some(services) = self.fetch_app(app_name).await? else {
             return Ok(App::empty());
         };
@@ -914,7 +910,7 @@ impl HttpForwarder for K8sHttpForwarder {
             hyper::client::conn::http1::handshake(TokioIo::new(port)).await?;
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                warn!("Error in connection: {}", e);
+                warn!("Error in connection: {e}");
             }
         });
 

--- a/api/src/infrastructure/mod.rs
+++ b/api/src/infrastructure/mod.rs
@@ -45,7 +45,6 @@ static SERVICE_NAME_LABEL: &str = "com.aixigo.preview.servant.service-name";
 static CONTAINER_TYPE_LABEL: &str = "com.aixigo.preview.servant.container-type";
 static REPLICATED_ENV_LABEL: &str = "com.aixigo.preview.servant.replicated-env";
 static IMAGE_LABEL: &str = "com.aixigo.preview.servant.image";
-static STATUS_ID: &str = "com.aixigo.preview.servant.status-id";
 static STORAGE_TYPE_LABEL: &str = "com.aixigo.preview.servant.storage-type";
 static USER_DEFINED_PARAMETERS_LABEL: &str = "com.aixigo.preview.servant.user-defined";
 static OWNERS_LABEL: &str = "com.aixigo.preview.servant.owners";

--- a/api/src/models/app.rs
+++ b/api/src/models/app.rs
@@ -146,6 +146,10 @@ impl App {
         &self.services
     }
 
+    pub fn owners(&self) -> &HashSet<Owner> {
+        &self.owners
+    }
+
     pub fn is_empty(&self) -> bool {
         self.services.is_empty()
     }

--- a/api/src/webhooks.rs
+++ b/api/src/webhooks.rs
@@ -24,7 +24,7 @@
  * =========================LICENSE_END==================================
  */
 
-use crate::apps::Apps;
+use crate::apps::AppTaskQueueProducer;
 use crate::apps::{delete_app_sync, AppV1};
 use crate::auth::UserValidatedByAccessMode;
 use crate::http_result::HttpResult;
@@ -35,11 +35,10 @@ use log::info;
 use rocket::serde::json::Json;
 use rocket::State;
 use std::str::FromStr;
-use std::sync::Arc;
 
 #[rocket::post("/webhooks", format = "application/json", data = "<web_hook_info>")]
 pub async fn webhooks(
-    apps: &State<Arc<Apps>>,
+    app_queue: &State<AppTaskQueueProducer>,
     web_hook_info: WebHookInfo,
     user: Result<UserValidatedByAccessMode, HttpApiProblem>,
 ) -> HttpResult<Json<AppV1>> {
@@ -51,5 +50,5 @@ pub async fn webhooks(
     );
 
     let app_name = AppName::from_str(&web_hook_info.get_app_name());
-    delete_app_sync(app_name, apps, user).await
+    delete_app_sync(app_name, app_queue, user).await
 }

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -27,14 +27,14 @@ import { EventSource } from 'eventsource';
 import { Store } from 'vuex';
 
 const SERVICE_TYPE_ORDER = [
-    'instance',
-    'replica',
-    'app-companion',
-    'service-companion'
+   'instance',
+   'replica',
+   'app-companion',
+   'service-companion'
 ];
 
 export function createStore(router, me, issuers) {
-   const store = new Store( {
+   const store = new Store({
       state: {
          fetchInProgress: false,
          apps: {},
@@ -52,58 +52,58 @@ export function createStore(router, me, issuers) {
          appNameFilter: state => state.appNameFilter,
 
          reviewApps: state => {
-            if ( state.apps === undefined || Object.keys( state.apps ).length == 0 ) {
+            if (state.apps === undefined || Object.keys(state.apps).length == 0) {
                return [];
             }
 
             const apps = [
-               appDetails( 'master' ),
-               ...Object.keys( state.apps )
-                  .filter( _ => _ != 'master' )
-                  .map( appDetails )
-                  .sort( byAppNameDesc )
+               appDetails('master'),
+               ...Object.keys(state.apps)
+                  .filter(_ => _ != 'master')
+                  .map(appDetails)
+                  .sort(byAppNameDesc)
             ];
 
             return apps
-                .filter( app => app.name != null )
-                .filter( app => !state.appNameFilter || app.name.toLocaleLowerCase().indexOf( state.appNameFilter.toLocaleLowerCase() ) >= 0 );
+               .filter(app => app.name != null)
+               .filter(app => !state.appNameFilter || app.name.toLocaleLowerCase().indexOf(state.appNameFilter.toLocaleLowerCase()) >= 0);
 
-            function appDetails( name ) {
-               const appContainers = state.apps[ name ];
+            function appDetails(name) {
+               const appContainers = state.apps[name];
 
                if (appContainers == null) {
                   return {};
                }
 
-               const ticket = state.tickets[ name ];
+               const ticket = state.tickets[name];
                const owners = appContainers.owners;
 
                const containers = [
                   ...appContainers
                      .services
-                     .map( ( { name, url, openApiUrl, asyncApiUrl, version, type, state } ) => {
+                     .map(({ name, url, openApiUrl, asyncApiUrl, version, type, state }) => {
                         return {
-                            name, url, openApiUrl, asyncApiUrl, version, type, status: state.status
+                           name, url, openApiUrl, asyncApiUrl, version, type, status: state.status
                         };
-                     } )
+                     })
                ];
-               containers.sort( byTypeAndName );
+               containers.sort(byTypeAndName);
                return { name, ticket, containers, owners };
             }
 
-             function byTypeAndName(containerA, containerB) {
-                 const typeIndexA = SERVICE_TYPE_ORDER.indexOf(containerA.type);
-                 const typeIndexB = SERVICE_TYPE_ORDER.indexOf(containerB.type);
+            function byTypeAndName(containerA, containerB) {
+               const typeIndexA = SERVICE_TYPE_ORDER.indexOf(containerA.type);
+               const typeIndexB = SERVICE_TYPE_ORDER.indexOf(containerB.type);
 
-                 if (typeIndexA !== typeIndexB) {
-                     return typeIndexA < typeIndexB ? -1 : 1;
-                 }
+               if (typeIndexA !== typeIndexB) {
+                  return typeIndexA < typeIndexB ? -1 : 1;
+               }
 
-                 return containerA.name < containerB.name ? -1 : 1;
-             }
+               return containerA.name < containerB.name ? -1 : 1;
+            }
 
-            function byAppNameDesc( appA, appB ) {
-               const [ keyA, keyB ] = [ appA, appB ].map( ( { name } ) => name );
+            function byAppNameDesc(appA, appB) {
+               const [keyA, keyB] = [appA, appB].map(({ name }) => name);
                return keyA > keyB ? -1 : 1;
             }
          },
@@ -119,24 +119,24 @@ export function createStore(router, me, issuers) {
 
          appsWithTicket: (state, getters) => {
             return getters.reviewApps
-               .filter( app => !getters.myApps.some(myApp => app.name == myApp.name) )
-               .filter( app => state.tickets[ app.name ] !== undefined );
+               .filter(app => !getters.myApps.some(myApp => app.name == myApp.name))
+               .filter(app => state.tickets[app.name] !== undefined);
          },
 
          appsWithoutTicket: (state, getters) => {
             return getters.reviewApps
-               .filter( app => !getters.myApps.some(myApp => app.name == myApp.name) )
-               .filter( app => state.tickets[ app.name ] === undefined );
+               .filter(app => !getters.myApps.some(myApp => app.name == myApp.name))
+               .filter(app => state.tickets[app.name] === undefined);
          },
 
          errors: state => {
             const errors = [];
 
-            if( state.appsError ) {
-               errors.push( state.appsError );
+            if (state.appsError) {
+               errors.push(state.appsError);
             }
-            if( state.ticketsError ) {
-               errors.push( state.ticketsError );
+            if (state.ticketsError) {
+               errors.push(state.ticketsError);
             }
 
             return errors;
@@ -145,15 +145,15 @@ export function createStore(router, me, issuers) {
          isFetchInProgress: state => state.fetchInProgress
       },
       mutations: {
-         startFetch( state ) {
+         startFetch(state) {
             state.fetchInProgress = true;
          },
-         endFetch( state ) {
+         endFetch(state) {
             state.fetchInProgress = false;
          },
 
-         storeApps( state, appsResponse ) {
-            if( appsResponse.type ) {
+         storeApps(state, appsResponse) {
+            if (appsResponse.type) {
                state.apps = {};
                state.appsError = appsResponse;
             }
@@ -163,28 +163,28 @@ export function createStore(router, me, issuers) {
             }
          },
 
-         deleteApp( state, appNameOrResponseError ) {
-            if( appNameOrResponseError.type ) {
+         deleteApp(state, appNameOrResponseError) {
+            if (appNameOrResponseError.type) {
                state.appsError = appNameOrResponseError;
             }
             else {
-               delete state.apps[ appNameOrResponseError ];
+               delete state.apps[appNameOrResponseError];
                state.appsError = null;
             }
          },
 
-         addApp( state, { appName, servicesOrResponseError } ) {
-            if( servicesOrResponseError.type ) {
+         addApp(state, { appName, servicesOrResponseError }) {
+            if (servicesOrResponseError.type) {
                state.appsError = servicesOrResponseError;
             }
             else {
-               state.apps[ appName ] = servicesOrResponseError;
+               state.apps[appName] = servicesOrResponseError;
                state.appsError = null;
             }
          },
 
-         storeTickets( state, ticketsResponse ) {
-            if( ticketsResponse.type ) {
+         storeTickets(state, ticketsResponse) {
+            if (ticketsResponse.type) {
                state.tickets = {};
                state.ticketsError = ticketsResponse;
             }
@@ -194,38 +194,38 @@ export function createStore(router, me, issuers) {
             }
          },
 
-         updateServiceStatus( state, { appName, serviceName, serviceStatus } ) {
+         updateServiceStatus(state, { appName, serviceName, serviceStatus }) {
             const service = state.apps[appName].find(service => service.name == serviceName);
             service.state.status = serviceStatus;
          },
 
-         filterByAppName( state, appNameFilter ) {
+         filterByAppName(state, appNameFilter) {
             state.appNameFilter = appNameFilter.toLocaleLowerCase();
             router.replace({ query: { appNameFilter } });
          }
       },
       actions: {
-         fetchData( context ) {
+         fetchData(context) {
             function fetchTicketsHandler(response) {
-               if( response.ok ) {
-                  if( response.status === 200 ) {
+               if (response.ok) {
+                  if (response.status === 200) {
                      return response.json();
                   }
                   else {
                      return Promise.resolve({});
                   }
                }
-               if( response.headers.get('Content-Type') === 'application/problem+json' ) {
+               if (response.headers.get('Content-Type') === 'application/problem+json') {
                   return response.json();
                }
-               return response.text().then( detail => ({
+               return response.text().then(detail => ({
                   type: 'cannot-fetch-tickets',
                   title: 'Cannot fetch tickets',
                   detail
                }));
             }
 
-            context.commit( 'startFetch' );
+            context.commit('startFetch');
 
             const appEvents = new EventSource('/api/apps', {
                fetch: (input, init) => fetch(input, {
@@ -239,19 +239,19 @@ export function createStore(router, me, issuers) {
             appEvents.addEventListener('message', (event) => {
                const apps = JSON.parse(event.data);
 
-               context.commit( 'endFetch' );
+               context.commit('endFetch');
                context.commit("storeApps", apps);
 
-               fetch( '/api/apps/tickets' )
+               fetch('/api/apps/tickets')
                   .then(fetchTicketsHandler)
                   .then(tickets => context.commit("storeTickets", tickets));
             });
          },
 
-         changeServiceState( context, { appName, serviceName } ) {
-            const service = context.state.apps[ appName ].find( service => service.name === serviceName );
+         changeServiceState(context, { appName, serviceName }) {
+            const service = context.state.apps[appName].find(service => service.name === serviceName);
             let newStatus;
-            if( service.state.status === 'running' ) {
+            if (service.state.status === 'running') {
                newStatus = 'paused';
             } else {
                newStatus = 'running';
@@ -263,18 +263,18 @@ export function createStore(router, me, issuers) {
                   'Content-Type': 'application/json',
                   'Accept': 'application/json',
                },
-               body: JSON.stringify( { status: newStatus } )
+               body: JSON.stringify({ status: newStatus })
             }).then(response => {
-               if( response.status === 202 ) {
-                  context.commit( "updateServiceStatus", { appName, serviceName, serviceStatus: newStatus } );
+               if (response.status === 202) {
+                  context.commit("updateServiceStatus", { appName, serviceName, serviceStatus: newStatus });
                }
             });
          },
 
-         duplicateApp( context, { appToDuplicate, newAppName } ) {
-            context.commit( 'startFetch' );
+         duplicateApp(context, { appToDuplicate, newAppName }) {
+            context.commit('startFetch');
 
-            fetch(
+            fetchAndPoll(
                `/api/apps/${newAppName}?replicateFrom=${appToDuplicate}`,
                {
                   method: 'POST',
@@ -283,49 +283,28 @@ export function createStore(router, me, issuers) {
                      'Accept': 'application/json'
                   },
                   body: JSON.stringify([])
-               } )
-               .then( response => {
-                  const contentType = response.headers.get('Content-Type');
-                  if( contentType === 'application/json' || contentType === 'application/problem+json' ) {
-                     return response.json();
-                  }
-                  return response.text().then( detail => ({
-                     type: 'cannot-duplicate-app',
-                     title: 'Cannot duplicate app',
-                     detail
-                  }));
                })
-               .then( servicesOrResponseError => {
-                  context.commit( 'addApp', { appName: newAppName, servicesOrResponseError } );
-                  context.commit( 'endFetch' );
+               .then(servicesOrResponseError => {
+                  context.commit('addApp', { appName: newAppName, servicesOrResponseError });
+                  context.commit('endFetch');
                });
          },
 
-         deleteApp( context, { appName } ) {
-            context.commit( 'startFetch' );
+         deleteApp(context, { appName }) {
+            context.commit('startFetch');
 
-            fetch(`/api/apps/${appName}`, { method: 'DELETE' })
-               .then( response => {
-                  if( response.status == 200 ) {
-                     return appName;
-                  }
-
-                  if( response.headers.get('Content-Type') === 'application/problem+json' ) {
-                     return response.json();
-                  }
-                  return response.text().then( detail => ({
-                     type: 'cannot-delete-app',
-                     title: 'Cannot delete app',
-                     detail
-                  }));
-               })
-               .then( appNameOrResponseError => {
-                  context.commit( 'deleteApp', appNameOrResponseError );
-                  context.commit( 'endFetch' );
-               })
+            fetchAndPoll(
+               `/api/apps/${appName}`,
+               { method: 'DELETE' },
+               'cannot-delete-app',
+               'Cannot delete app',
+            ).then(appNameOrResponseError => {
+               context.commit('deleteApp', appNameOrResponseError);
+               context.commit('endFetch');
+            })
          }
       }
-   } );
+   });
 
 
    router.beforeResolve(to => {
@@ -338,4 +317,70 @@ export function createStore(router, me, issuers) {
    });
 
    return store;
+}
+
+async function fetchAndPoll(url, init, problemType, problemTitle) {
+   const prefer = {
+      'Accept': 'application/vnd.prevant.v2+json',
+      'Prefer': 'respond-async,wait=10'
+   };
+
+   async function pollLocation(location) {
+      const maxRetries = 60;
+      const retryInterval = 2000
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+
+         const response = await fetch(location, { headers: prefer });
+
+         if (response.status === 202) {
+            await new Promise(resolve => setTimeout(resolve, retryInterval));
+         } else if (response.ok) {
+            return await response.json();
+         } else if (response.headers.get('Content-Type') === 'application/problem+json') {
+            return await response.json();
+         } else {
+            return response.text().then(detail => ({
+               type: problemType,
+               title: problemTitle,
+               detail
+            }))
+         }
+      }
+
+      throw new Error('Polling failed after maximum retries');
+   }
+
+   try {
+      init.headers = init.headers ? { ...init.headers, ...prefer } : prefer;
+
+      const response = await fetch(url, init);
+
+      if (response.status == 202) {
+         const location = response.headers.get('Location');
+         if (!location) {
+            throw new Error('Location header is missing in the 202 response');
+         }
+
+         return await pollLocation(location);
+      }
+
+      if (response.ok) {
+         return await response.json();
+      }
+
+      if (response.headers.get('Content-Type') === 'application/problem+json') {
+         return await response.json();
+      }
+
+      return response.text().then(detail => ({
+         type: problemType,
+         title: problemTitle,
+         detail
+      }));
+   }
+   catch (error) {
+      console.error('Error triggering or polling API:', error);
+      throw error;
+   }
 }


### PR DESCRIPTION
This commit brings an in-memory producer-consumer queue that avoids the
409 conflict when interacting with the infrastructure.

Addresses #40. In follow-up PR there will be support for PostgreSQL persistent queues (https://postgresforeverything.com/)