### PR TITLE
feat: allow configuring the title of the frontend

### DIFF
--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -176,7 +176,7 @@ where
     }
 }
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Default)]
 pub struct FrontendConfig {
     #[serde(default)]
     pub title: Option<String>,
@@ -217,7 +217,8 @@ pub struct Config {
     applications: Applications,
     containers: Option<ContainerConfig>,
     jira: Option<JiraConfig>,
-    frontend: Option<FrontendConfig>,
+    #[serde(default)]
+    pub frontend: FrontendConfig,
     #[serde(default)]
     companions: Companions,
     services: Option<BTreeMap<String, Service>>,
@@ -264,18 +265,6 @@ impl Config {
             Some(containers) => containers.clone(),
             None => ContainerConfig::default(),
         }
-    }
-
-    pub fn frontend_config(&self) -> Option<FrontendConfig> {
-        self.frontend.as_ref().cloned()
-    }
-
-    pub fn frontend_title(&self) -> String {
-        self.frontend_config()
-            .as_ref()
-            .and_then(|fe| fe.title())
-            .cloned()
-            .unwrap_or_else(|| "PREvant".to_string())
     }
 
     pub fn jira_config(&self) -> Option<JiraConfig> {
@@ -521,12 +510,6 @@ impl<'de> Deserialize<'de> for ApiAccess {
             }),
             openid_providers,
         })
-    }
-}
-
-impl FrontendConfig {
-    pub fn title(&self) -> Option<&String> {
-        self.title.as_ref()
     }
 }
 
@@ -1041,27 +1024,27 @@ mod tests {
             "#
         );
 
-        assert_eq!(config.frontend_title(), "My Custom Title");
+        assert_eq!(config.frontend.title, Some(String::from("My Custom Title")));
     }
 
     #[test]
-    fn should_return_default_frontend_title_when_missing_frontend_title_config() {
+    fn should_return_none_when_missing_frontend_title_config() {
         let config = config_from_str!(
             r#"
             [frontend]
             "#
         );
 
-        assert_eq!(config.frontend_title(), "PREvant");
+        assert_eq!(config.frontend.title, None);
     }
 
     #[test]
-    fn should_return_default_frontend_title_when_missing_frontend_config_section() {
+    fn should_return_none_when_missing_frontend_config_section() {
         let config = config_from_str!(
             r#"
             "#
         );
-        assert_eq!(config.frontend_title(), "PREvant");
+        assert_eq!(config.frontend.title, None);
     }
 
     #[test]

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -177,6 +177,12 @@ where
 }
 
 #[derive(Clone, Deserialize)]
+pub struct FrontendConfig {
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Clone, Deserialize)]
 pub struct JiraConfig {
     host: String,
     #[serde(flatten)]
@@ -211,6 +217,7 @@ pub struct Config {
     applications: Applications,
     containers: Option<ContainerConfig>,
     jira: Option<JiraConfig>,
+    frontend: Option<FrontendConfig>,
     #[serde(default)]
     companions: Companions,
     services: Option<BTreeMap<String, Service>>,
@@ -257,6 +264,10 @@ impl Config {
             Some(containers) => containers.clone(),
             None => ContainerConfig::default(),
         }
+    }
+
+    pub fn frontend_config(&self) -> Option<FrontendConfig> {
+        self.frontend.as_ref().cloned()
     }
 
     pub fn jira_config(&self) -> Option<JiraConfig> {
@@ -502,6 +513,12 @@ impl<'de> Deserialize<'de> for ApiAccess {
             }),
             openid_providers,
         })
+    }
+}
+
+impl FrontendConfig {
+    pub fn title(&self) -> Option<&String> {
+        self.title.as_ref()
     }
 }
 

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -270,6 +270,14 @@ impl Config {
         self.frontend.as_ref().cloned()
     }
 
+    pub fn frontend_title(&self) -> String {
+        self.frontend_config()
+            .as_ref()
+            .and_then(|fe| fe.title())
+            .cloned()
+            .unwrap_or_else(|| "PREvant".to_string())
+    }
+
     pub fn jira_config(&self) -> Option<JiraConfig> {
         self.jira.as_ref().cloned()
     }
@@ -1022,6 +1030,38 @@ mod tests {
                 api_key: SecUtf8::from_str("key").unwrap()
             }
         );
+    }
+
+    #[test]
+    fn should_return_custom_frontend_title_when_provided() {
+        let config = config_from_str!(
+            r#"
+            [frontend]
+            title = "My Custom Title"
+            "#
+        );
+
+        assert_eq!(config.frontend_title(), "My Custom Title");
+    }
+
+    #[test]
+    fn should_return_default_frontend_title_when_missing_frontend_title_config() {
+        let config = config_from_str!(
+            r#"
+            [frontend]
+            "#
+        );
+
+        assert_eq!(config.frontend_title(), "PREvant");
+    }
+
+    #[test]
+    fn should_return_default_frontend_title_when_missing_frontend_config_section() {
+        let config = config_from_str!(
+            r#"
+            "#
+        );
+        assert_eq!(config.frontend_title(), "PREvant");
     }
 
     #[test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -90,7 +90,7 @@ async fn openapi(request_info: RequestInfo) -> Option<String> {
 struct Index(String);
 
 #[rocket::get("/")]
-async fn index(user: User, issuers: &State<Issuers>, config_state: &State<Config>) -> HttpResult<Index> {
+async fn index(user: User, issuers: &State<Issuers>, config: &State<Config>) -> HttpResult<Index> {
     use handlebars::Handlebars;
 
     let index_path = Path::new("frontend").join("index.html");
@@ -133,7 +133,7 @@ async fn index(user: User, issuers: &State<Issuers>, config_state: &State<Config
     data.insert("me", me.to_string());
     data.insert("issuers", issuers.inner().to_string());
 
-    data.insert("title", config_state.frontend_title());
+    data.insert("title", config.frontend.title.as_deref().unwrap_or("PREvant").to_string());
 
     Ok(Index(handlebars.render("index", &data).map_err(|e| {
         HttpApiError::from(

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -133,13 +133,7 @@ async fn index(user: User, issuers: &State<Issuers>, config_state: &State<Config
     data.insert("me", me.to_string());
     data.insert("issuers", issuers.inner().to_string());
 
-    let title = config_state
-        .frontend_config()
-        .as_ref()
-        .and_then(|fe| fe.title())
-        .cloned()
-        .unwrap_or_else(|| "PREvant".to_string());
-    data.insert("title", title);
+    data.insert("title", config_state.frontend_title());
 
     Ok(Index(handlebars.render("index", &data).map_err(|e| {
         HttpApiError::from(

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -90,7 +90,7 @@ async fn openapi(request_info: RequestInfo) -> Option<String> {
 struct Index(String);
 
 #[rocket::get("/")]
-async fn index(user: User, issuers: &State<Issuers>) -> HttpResult<Index> {
+async fn index(user: User, issuers: &State<Issuers>, config_state: &State<Config>) -> HttpResult<Index> {
     use handlebars::Handlebars;
 
     let index_path = Path::new("frontend").join("index.html");
@@ -132,6 +132,14 @@ async fn index(user: User, issuers: &State<Issuers>) -> HttpResult<Index> {
     };
     data.insert("me", me.to_string());
     data.insert("issuers", issuers.inner().to_string());
+
+    let title = config_state
+        .frontend_config()
+        .as_ref()
+        .and_then(|fe| fe.title())
+        .cloned()
+        .unwrap_or_else(|| "PREvant".to_string());
+    data.insert("title", title);
 
     Ok(Index(handlebars.render("index", &data).map_err(|e| {
         HttpApiError::from(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,15 @@ user = ''
 password = ''
 ```
 
+## Frontend options
+
+PREvant provides configuration options to customize the frontend. Currently, you can set the title of the HTML document:
+
+```toml
+[frontend]
+title = 'My Environment'
+```
+
 ## Services
 
 PREvant offers centralized configuration options for services deployed via its REST-API. For example, you can specify that PREvant mounts a secret for a specific service of an application.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,6 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" sizes="any">
-
-    <title>PREvant</title>
 </head>
 <body>
 

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -19,11 +19,18 @@ export default defineConfig({
          name: "inject-me-build",
          apply: "build",
          transformIndexHtml(_html) {
-            return [{
-               injectTo: "head",
-               tag: "script",
-               children: "var me = {{ me }}; var issuers = {{ issuers }};"
-            }];
+            return [
+               {
+                  injectTo: "head",
+                  tag: "script",
+                  children: "var me = {{ me }}; var issuers = {{ issuers }};"
+               }, 
+               {
+                  injectTo: "head",
+                  tag: "title",
+                  children: "{{ title }}"
+               }
+            ];
          }
       },
       {
@@ -72,11 +79,18 @@ export default defineConfig({
                })
                .catch(() => null);
 
-            return [{
-               injectTo: "head",
-               tag: "script",
-               children: `var me = ${JSON.stringify(me)}; var issuers = ${JSON.stringify(issuers)}`
-            }];
+            return [
+               {
+                  injectTo: "head",
+                  tag: "script",
+                  children: `var me = ${JSON.stringify(me)}; var issuers = ${JSON.stringify(issuers)}`
+               }, 
+               {
+                  injectTo: "head",
+                  tag: "title",
+                  children: "PREvant (dev)"
+               }
+            ];
          }
       },
 

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
       vue(),
 
       {
-         name: "inject-me-build",
+         name: "inject-template-vars",
          apply: "build",
          transformIndexHtml(_html) {
             return [
@@ -49,7 +49,7 @@ export default defineConfig({
          },
       },
       {
-         name: "inject-me",
+         name: "inject-runtime-context",
          apply: "serve",
          async transformIndexHtml(_html) {
             const me= await fetch("http://127.0.0.1:8000/auth/me", {


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option that allows customizing the document title of the frontend.

## Details

- Reuses the existing Vite plugin logic for transforming the index.html.
- Development mode: the title is hardcoded to  "PREvant (dev)" to clearly indicate the dev server is being used.
- Production build: the title is set via Mustache template variables, which the backend expands when serving the index file.

## User-facing Changes

Users can now configure the HTML document title through PREvant.toml:

```toml
[frontend]
title = 'My Environment'
```