### PR TITLE
deps(frontend): update dependencies, mitigate deprecation warnings

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install dependencies
         working-directory: frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Frontend
-FROM node:18-alpine AS frontend-builder
+FROM node:22-alpine AS frontend-builder
 WORKDIR /usr/src/frontend/
 COPY frontend/package.json frontend/index.html frontend/package-lock.json frontend/*.config.mjs /usr/src/frontend/
 COPY frontend/public /usr/src/frontend/public/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,6 @@
             "@fortawesome/free-solid-svg-icons": "^5.15.4",
             "@fortawesome/vue-fontawesome": "^3.0.3",
             "bootstrap-material-design": "^4.1.3",
-            "core-js": "^3.45.1",
             "eventsource": "^4.0.0",
             "http-link-header": "^1.1.3",
             "jquery": "^3.7.1",
@@ -2969,17 +2968,6 @@
          "license": "MIT",
          "dependencies": {
             "toggle-selection": "^1.0.6"
-         }
-      },
-      "node_modules/core-js": {
-         "version": "3.45.1",
-         "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-         "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
-         "hasInstallScript": true,
-         "license": "MIT",
-         "funding": {
-            "type": "opencollective",
-            "url": "https://opencollective.com/core-js"
          }
       },
       "node_modules/core-js-pure": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
             "moment": "^2.30.1",
             "popper.js": "^1.16.1",
             "swagger-ui": "^5.27.1",
-            "vue": "^3.5.20",
+            "vue": "^3.5.21",
             "vue-router": "^4.5.1",
             "vue-virtual-scroller": "^2.0.0-beta.8",
             "vuex": "^4.1.0"
@@ -2484,53 +2484,53 @@
          }
       },
       "node_modules/@vue/compiler-core": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.20.tgz",
-         "integrity": "sha512-8TWXUyiqFd3GmP4JTX9hbiTFRwYHgVL/vr3cqhr4YQ258+9FADwvj7golk2sWNGHR67QgmCZ8gz80nQcMokhwg==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.21.tgz",
+         "integrity": "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==",
          "license": "MIT",
          "dependencies": {
             "@babel/parser": "^7.28.3",
-            "@vue/shared": "3.5.20",
+            "@vue/shared": "3.5.21",
             "entities": "^4.5.0",
             "estree-walker": "^2.0.2",
             "source-map-js": "^1.2.1"
          }
       },
       "node_modules/@vue/compiler-dom": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.20.tgz",
-         "integrity": "sha512-whB44M59XKjqUEYOMPYU0ijUV0G+4fdrHVKDe32abNdX/kJe1NUEMqsi4cwzXa9kyM9w5S8WqFsrfo1ogtBZGQ==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.21.tgz",
+         "integrity": "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==",
          "license": "MIT",
          "dependencies": {
-            "@vue/compiler-core": "3.5.20",
-            "@vue/shared": "3.5.20"
+            "@vue/compiler-core": "3.5.21",
+            "@vue/shared": "3.5.21"
          }
       },
       "node_modules/@vue/compiler-sfc": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.20.tgz",
-         "integrity": "sha512-SFcxapQc0/feWiSBfkGsa1v4DOrnMAQSYuvDMpEaxbpH5dKbnEM5KobSNSgU+1MbHCl+9ftm7oQWxvwDB6iBfw==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.21.tgz",
+         "integrity": "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==",
          "license": "MIT",
          "dependencies": {
             "@babel/parser": "^7.28.3",
-            "@vue/compiler-core": "3.5.20",
-            "@vue/compiler-dom": "3.5.20",
-            "@vue/compiler-ssr": "3.5.20",
-            "@vue/shared": "3.5.20",
+            "@vue/compiler-core": "3.5.21",
+            "@vue/compiler-dom": "3.5.21",
+            "@vue/compiler-ssr": "3.5.21",
+            "@vue/shared": "3.5.21",
             "estree-walker": "^2.0.2",
-            "magic-string": "^0.30.17",
+            "magic-string": "^0.30.18",
             "postcss": "^8.5.6",
             "source-map-js": "^1.2.1"
          }
       },
       "node_modules/@vue/compiler-ssr": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.20.tgz",
-         "integrity": "sha512-RSl5XAMc5YFUXpDQi+UQDdVjH9FnEpLDHIALg5J0ITHxkEzJ8uQLlo7CIbjPYqmZtt6w0TsIPbo1izYXwDG7JA==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.21.tgz",
+         "integrity": "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==",
          "license": "MIT",
          "dependencies": {
-            "@vue/compiler-dom": "3.5.20",
-            "@vue/shared": "3.5.20"
+            "@vue/compiler-dom": "3.5.21",
+            "@vue/shared": "3.5.21"
          }
       },
       "node_modules/@vue/devtools-api": {
@@ -2540,53 +2540,53 @@
          "license": "MIT"
       },
       "node_modules/@vue/reactivity": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.20.tgz",
-         "integrity": "sha512-hS8l8x4cl1fmZpSQX/NXlqWKARqEsNmfkwOIYqtR2F616NGfsLUm0G6FQBK6uDKUCVyi1YOL8Xmt/RkZcd/jYQ==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.21.tgz",
+         "integrity": "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==",
          "license": "MIT",
          "dependencies": {
-            "@vue/shared": "3.5.20"
+            "@vue/shared": "3.5.21"
          }
       },
       "node_modules/@vue/runtime-core": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.20.tgz",
-         "integrity": "sha512-vyQRiH5uSZlOa+4I/t4Qw/SsD/gbth0SW2J7oMeVlMFMAmsG1rwDD6ok0VMmjXY3eI0iHNSSOBilEDW98PLRKw==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.21.tgz",
+         "integrity": "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==",
          "license": "MIT",
          "dependencies": {
-            "@vue/reactivity": "3.5.20",
-            "@vue/shared": "3.5.20"
+            "@vue/reactivity": "3.5.21",
+            "@vue/shared": "3.5.21"
          }
       },
       "node_modules/@vue/runtime-dom": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.20.tgz",
-         "integrity": "sha512-KBHzPld/Djw3im0CQ7tGCpgRedryIn4CcAl047EhFTCCPT2xFf4e8j6WeKLgEEoqPSl9TYqShc3Q6tpWpz/Xgw==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.21.tgz",
+         "integrity": "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==",
          "license": "MIT",
          "dependencies": {
-            "@vue/reactivity": "3.5.20",
-            "@vue/runtime-core": "3.5.20",
-            "@vue/shared": "3.5.20",
+            "@vue/reactivity": "3.5.21",
+            "@vue/runtime-core": "3.5.21",
+            "@vue/shared": "3.5.21",
             "csstype": "^3.1.3"
          }
       },
       "node_modules/@vue/server-renderer": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.20.tgz",
-         "integrity": "sha512-HthAS0lZJDH21HFJBVNTtx+ULcIbJQRpjSVomVjfyPkFSpCwvsPTA+jIzOaUm3Hrqx36ozBHePztQFg6pj5aKg==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.21.tgz",
+         "integrity": "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==",
          "license": "MIT",
          "dependencies": {
-            "@vue/compiler-ssr": "3.5.20",
-            "@vue/shared": "3.5.20"
+            "@vue/compiler-ssr": "3.5.21",
+            "@vue/shared": "3.5.21"
          },
          "peerDependencies": {
-            "vue": "3.5.20"
+            "vue": "3.5.21"
          }
       },
       "node_modules/@vue/shared": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.20.tgz",
-         "integrity": "sha512-SoRGP596KU/ig6TfgkCMbXkr4YJ91n/QSdMuqeP5r3hVIYA3CPHUBCc7Skak0EAKV+5lL4KyIh61VA/pK1CIAA==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.21.tgz",
+         "integrity": "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==",
          "license": "MIT"
       },
       "node_modules/abort-controller": {
@@ -6353,16 +6353,16 @@
          }
       },
       "node_modules/vue": {
-         "version": "3.5.20",
-         "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.20.tgz",
-         "integrity": "sha512-2sBz0x/wis5TkF1XZ2vH25zWq3G1bFEPOfkBcx2ikowmphoQsPH6X0V3mmPCXA2K1N/XGTnifVyDQP4GfDDeQw==",
+         "version": "3.5.21",
+         "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.21.tgz",
+         "integrity": "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==",
          "license": "MIT",
          "dependencies": {
-            "@vue/compiler-dom": "3.5.20",
-            "@vue/compiler-sfc": "3.5.20",
-            "@vue/runtime-dom": "3.5.20",
-            "@vue/server-renderer": "3.5.20",
-            "@vue/shared": "3.5.20"
+            "@vue/compiler-dom": "3.5.21",
+            "@vue/compiler-sfc": "3.5.21",
+            "@vue/runtime-dom": "3.5.21",
+            "@vue/server-renderer": "3.5.21",
+            "@vue/shared": "3.5.21"
          },
          "peerDependencies": {
             "typescript": "*"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
             "jquery": "^3.7.1",
             "moment": "^2.30.1",
             "popper.js": "^1.16.1",
-            "swagger-ui": "^5.27.1",
+            "swagger-ui": "^5.28.1",
             "vue": "^3.5.21",
             "vue-router": "^4.5.1",
             "vue-virtual-scroller": "^2.0.0-beta.8",
@@ -2930,6 +2930,30 @@
          },
          "engines": {
             "node": ">=8"
+         }
+      },
+      "node_modules/buffer": {
+         "version": "6.0.3",
+         "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+         "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/feross"
+            },
+            {
+               "type": "patreon",
+               "url": "https://www.patreon.com/feross"
+            },
+            {
+               "type": "consulting",
+               "url": "https://feross.org/support"
+            }
+         ],
+         "license": "MIT",
+         "dependencies": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
          }
       },
       "node_modules/call-bind": {
@@ -6038,14 +6062,15 @@
          }
       },
       "node_modules/swagger-ui": {
-         "version": "5.27.1",
-         "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.27.1.tgz",
-         "integrity": "sha512-cGQyafnHLmVFiBeFrbUzUtMn+R0/XI7r69T/cxp5bkusTdLu1Ul8A+8j9hgThYLEH33LukOzldtiuu4gr8XE6g==",
+         "version": "5.28.1",
+         "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-5.28.1.tgz",
+         "integrity": "sha512-2/5TgOOPGmXAmR+YFaLi9D6Yazu/+dLfZnkZzG7ECZ9YKHuXsbLWtS0s5P1pZCijyChShMHFmfnFEQP2Hs/4wA==",
          "license": "Apache-2.0",
          "dependencies": {
             "@babel/runtime-corejs3": "^7.27.1",
             "@scarf/scarf": "=1.4.0",
             "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
             "classnames": "^2.5.1",
             "css.escape": "1.5.1",
             "deep-extend": "0.6.0",
@@ -6058,10 +6083,10 @@
             "prop-types": "^15.8.1",
             "randexp": "^0.5.3",
             "randombytes": "^2.1.0",
-            "react": ">=16.8.0 <19",
+            "react": ">=16.8.0 <20",
             "react-copy-to-clipboard": "5.1.0",
             "react-debounce-input": "=3.3.0",
-            "react-dom": ">=16.8.0 <19",
+            "react-dom": ">=16.8.0 <20",
             "react-immutable-proptypes": "2.2.0",
             "react-immutable-pure-component": "^2.2.0",
             "react-inspector": "^6.0.1",
@@ -6072,7 +6097,7 @@
             "remarkable": "^2.0.1",
             "reselect": "^5.1.1",
             "serialize-error": "^8.1.0",
-            "sha.js": "^2.4.11",
+            "sha.js": "^2.4.12",
             "swagger-client": "^3.35.5",
             "url-parse": "^1.5.10",
             "xml": "=1.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
          "version": "0.9.0",
          "license": "MIT",
          "dependencies": {
-            "@asyncapi/react-component": "^2.6.3",
+            "@asyncapi/react-component": "^2.6.4",
             "@fortawesome/fontawesome-svg-core": "^1.2.36",
             "@fortawesome/free-solid-svg-icons": "^5.15.4",
             "@fortawesome/vue-fontawesome": "^3.0.3",
@@ -98,9 +98,9 @@
          }
       },
       "node_modules/@asyncapi/protobuf-schema-parser": {
-         "version": "3.5.1",
-         "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.5.1.tgz",
-         "integrity": "sha512-rfSHrsJm+W5I10KhQGx2VZTBObw0w5fsMCcZJVSCV1E9YhKDUQkeH+78QBzuLdHtfo9ut90Ykx02wslpZlcu1A==",
+         "version": "3.6.0",
+         "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.6.0.tgz",
+         "integrity": "sha512-z6zVRAMi2bkkgjREoCIvUg7KcacyoEh+VIwQmEni/JPuPFMOD3oPv4kwoftEeiF2+gGiioeIxpkI5x7rmHf2Nw==",
          "license": "Apache-2.0",
          "dependencies": {
             "@asyncapi/parser": "^3.4.0",
@@ -112,15 +112,15 @@
          }
       },
       "node_modules/@asyncapi/react-component": {
-         "version": "2.6.3",
-         "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-2.6.3.tgz",
-         "integrity": "sha512-Cs42mJxw8TQcc9RL66EAMF/b5T+ERq0a3DrJRkqr8v0URmUw/D4r/wIVpLApt9AgED4okSNDZfLJYSBUWyRk2g==",
+         "version": "2.6.4",
+         "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-2.6.4.tgz",
+         "integrity": "sha512-2Cq+NeBtYrA+ovtE6EuXgpWDaKIW4OomSxN95eKx1ddtcUBdKizFlkQJMydhUowR17OwxnuLMuLuyfWZVQmVTA==",
          "license": "Apache-2.0",
          "dependencies": {
             "@asyncapi/avro-schema-parser": "^3.0.24",
             "@asyncapi/openapi-schema-parser": "^3.0.24",
             "@asyncapi/parser": "^3.3.0",
-            "@asyncapi/protobuf-schema-parser": "^3.5.1",
+            "@asyncapi/protobuf-schema-parser": "^3.6.0",
             "highlight.js": "^10.7.2",
             "isomorphic-dompurify": "^2.14.0",
             "marked": "^4.0.14",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,9 +28,9 @@
          "devDependencies": {
             "@playwright/test": "^1.55.0",
             "@rollup/plugin-inject": "^5.0.5",
-            "@vitejs/plugin-vue": "^5.2.4",
+            "@vitejs/plugin-vue": "^6.0.1",
             "sass": "1.91.0",
-            "vite": "^5.4.19"
+            "vite": "^7.1.4"
          }
       },
       "node_modules/@asamuzakjp/css-color": {
@@ -320,9 +320,9 @@
          }
       },
       "node_modules/@esbuild/aix-ppc64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-         "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+         "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
          "cpu": [
             "ppc64"
          ],
@@ -333,13 +333,13 @@
             "aix"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/android-arm": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-         "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+         "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
          "cpu": [
             "arm"
          ],
@@ -350,13 +350,13 @@
             "android"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/android-arm64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-         "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+         "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
          "cpu": [
             "arm64"
          ],
@@ -367,13 +367,13 @@
             "android"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/android-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-         "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+         "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
          "cpu": [
             "x64"
          ],
@@ -384,13 +384,13 @@
             "android"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/darwin-arm64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-         "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+         "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
          "cpu": [
             "arm64"
          ],
@@ -401,13 +401,13 @@
             "darwin"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/darwin-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-         "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+         "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
          "cpu": [
             "x64"
          ],
@@ -418,13 +418,13 @@
             "darwin"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/freebsd-arm64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-         "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+         "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
          "cpu": [
             "arm64"
          ],
@@ -435,13 +435,13 @@
             "freebsd"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/freebsd-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-         "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+         "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
          "cpu": [
             "x64"
          ],
@@ -452,13 +452,13 @@
             "freebsd"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-arm": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-         "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+         "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
          "cpu": [
             "arm"
          ],
@@ -469,13 +469,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-arm64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-         "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+         "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
          "cpu": [
             "arm64"
          ],
@@ -486,13 +486,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-ia32": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-         "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+         "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
          "cpu": [
             "ia32"
          ],
@@ -503,13 +503,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-loong64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-         "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+         "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
          "cpu": [
             "loong64"
          ],
@@ -520,13 +520,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-mips64el": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-         "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+         "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
          "cpu": [
             "mips64el"
          ],
@@ -537,13 +537,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-ppc64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-         "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+         "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
          "cpu": [
             "ppc64"
          ],
@@ -554,13 +554,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-riscv64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-         "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+         "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
          "cpu": [
             "riscv64"
          ],
@@ -571,13 +571,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-s390x": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-         "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+         "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
          "cpu": [
             "s390x"
          ],
@@ -588,13 +588,13 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/linux-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-         "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+         "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
          "cpu": [
             "x64"
          ],
@@ -605,13 +605,30 @@
             "linux"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
+         }
+      },
+      "node_modules/@esbuild/netbsd-arm64": {
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+         "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "netbsd"
+         ],
+         "engines": {
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/netbsd-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-         "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+         "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
          "cpu": [
             "x64"
          ],
@@ -622,13 +639,30 @@
             "netbsd"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
+         }
+      },
+      "node_modules/@esbuild/openbsd-arm64": {
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+         "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "openbsd"
+         ],
+         "engines": {
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/openbsd-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-         "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+         "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
          "cpu": [
             "x64"
          ],
@@ -639,13 +673,30 @@
             "openbsd"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
+         }
+      },
+      "node_modules/@esbuild/openharmony-arm64": {
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+         "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "openharmony"
+         ],
+         "engines": {
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/sunos-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-         "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+         "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
          "cpu": [
             "x64"
          ],
@@ -656,13 +707,13 @@
             "sunos"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/win32-arm64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-         "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+         "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
          "cpu": [
             "arm64"
          ],
@@ -673,13 +724,13 @@
             "win32"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/win32-ia32": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-         "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+         "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
          "cpu": [
             "ia32"
          ],
@@ -690,13 +741,13 @@
             "win32"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@esbuild/win32-x64": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-         "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+         "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
          "cpu": [
             "x64"
          ],
@@ -707,7 +758,7 @@
             "win32"
          ],
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          }
       },
       "node_modules/@fortawesome/fontawesome-common-types": {
@@ -1214,6 +1265,13 @@
          "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
          "license": "BSD-3-Clause"
       },
+      "node_modules/@rolldown/pluginutils": {
+         "version": "1.0.0-beta.29",
+         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.29.tgz",
+         "integrity": "sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==",
+         "dev": true,
+         "license": "MIT"
+      },
       "node_modules/@rollup/plugin-inject": {
          "version": "5.0.5",
          "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
@@ -1259,9 +1317,9 @@
          }
       },
       "node_modules/@rollup/rollup-android-arm-eabi": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.25.0.tgz",
-         "integrity": "sha512-CC/ZqFZwlAIbU1wUPisHyV/XRc5RydFrNLtgl3dGYskdwPZdt4HERtKm50a/+DtTlKeCq9IXFEWR+P6blwjqBA==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
+         "integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
          "cpu": [
             "arm"
          ],
@@ -1273,9 +1331,9 @@
          ]
       },
       "node_modules/@rollup/rollup-android-arm64": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.25.0.tgz",
-         "integrity": "sha512-/Y76tmLGUJqVBXXCfVS8Q8FJqYGhgH4wl4qTA24E9v/IJM0XvJCGQVSW1QZ4J+VURO9h8YCa28sTFacZXwK7Rg==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
+         "integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
          "cpu": [
             "arm64"
          ],
@@ -1287,9 +1345,9 @@
          ]
       },
       "node_modules/@rollup/rollup-darwin-arm64": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.25.0.tgz",
-         "integrity": "sha512-YVT6L3UrKTlC0FpCZd0MGA7NVdp7YNaEqkENbWQ7AOVOqd/7VzyHpgIpc1mIaxRAo1ZsJRH45fq8j4N63I/vvg==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
+         "integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
          "cpu": [
             "arm64"
          ],
@@ -1301,9 +1359,9 @@
          ]
       },
       "node_modules/@rollup/rollup-darwin-x64": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.25.0.tgz",
-         "integrity": "sha512-ZRL+gexs3+ZmmWmGKEU43Bdn67kWnMeWXLFhcVv5Un8FQcx38yulHBA7XR2+KQdYIOtD0yZDWBCudmfj6lQJoA==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
+         "integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
          "cpu": [
             "x64"
          ],
@@ -1315,9 +1373,9 @@
          ]
       },
       "node_modules/@rollup/rollup-freebsd-arm64": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.25.0.tgz",
-         "integrity": "sha512-xpEIXhiP27EAylEpreCozozsxWQ2TJbOLSivGfXhU4G1TBVEYtUPi2pOZBnvGXHyOdLAUUhPnJzH3ah5cqF01g==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
+         "integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
          "cpu": [
             "arm64"
          ],
@@ -1329,9 +1387,9 @@
          ]
       },
       "node_modules/@rollup/rollup-freebsd-x64": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.25.0.tgz",
-         "integrity": "sha512-sC5FsmZGlJv5dOcURrsnIK7ngc3Kirnx3as2XU9uER+zjfyqIjdcMVgzy4cOawhsssqzoAX19qmxgJ8a14Qrqw==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
+         "integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
          "cpu": [
             "x64"
          ],
@@ -1343,9 +1401,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.25.0.tgz",
-         "integrity": "sha512-uD/dbLSs1BEPzg564TpRAQ/YvTnCds2XxyOndAO8nJhaQcqQGFgv/DAVko/ZHap3boCvxnzYMa3mTkV/B/3SWA==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
+         "integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
          "cpu": [
             "arm"
          ],
@@ -1357,9 +1415,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.25.0.tgz",
-         "integrity": "sha512-ZVt/XkrDlQWegDWrwyC3l0OfAF7yeJUF4fq5RMS07YM72BlSfn2fQQ6lPyBNjt+YbczMguPiJoCfaQC2dnflpQ==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
+         "integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
          "cpu": [
             "arm"
          ],
@@ -1371,9 +1429,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-arm64-gnu": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.25.0.tgz",
-         "integrity": "sha512-qboZ+T0gHAW2kkSDPHxu7quaFaaBlynODXpBVnPxUgvWYaE84xgCKAPEYE+fSMd3Zv5PyFZR+L0tCdYCMAtG0A==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
+         "integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
          "cpu": [
             "arm64"
          ],
@@ -1385,9 +1443,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-arm64-musl": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.25.0.tgz",
-         "integrity": "sha512-ndWTSEmAaKr88dBuogGH2NZaxe7u2rDoArsejNslugHZ+r44NfWiwjzizVS1nUOHo+n1Z6qV3X60rqE/HlISgw==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
+         "integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
          "cpu": [
             "arm64"
          ],
@@ -1398,10 +1456,24 @@
             "linux"
          ]
       },
-      "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.25.0.tgz",
-         "integrity": "sha512-BVSQvVa2v5hKwJSy6X7W1fjDex6yZnNKy3Kx1JGimccHft6HV0THTwNtC2zawtNXKUu+S5CjXslilYdKBAadzA==",
+      "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
+         "integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
+         "cpu": [
+            "loong64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
+         "integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
          "cpu": [
             "ppc64"
          ],
@@ -1413,9 +1485,23 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.25.0.tgz",
-         "integrity": "sha512-G4hTREQrIdeV0PE2JruzI+vXdRnaK1pg64hemHq2v5fhv8C7WjVaeXc9P5i4Q5UC06d/L+zA0mszYIKl+wY8oA==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
+         "integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
+         "cpu": [
+            "riscv64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@rollup/rollup-linux-riscv64-musl": {
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
+         "integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
          "cpu": [
             "riscv64"
          ],
@@ -1427,9 +1513,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-s390x-gnu": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.25.0.tgz",
-         "integrity": "sha512-9T/w0kQ+upxdkFL9zPVB6zy9vWW1deA3g8IauJxojN4bnz5FwSsUAD034KpXIVX5j5p/rn6XqumBMxfRkcHapQ==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
+         "integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
          "cpu": [
             "s390x"
          ],
@@ -1441,9 +1527,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-x64-gnu": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.25.0.tgz",
-         "integrity": "sha512-ThcnU0EcMDn+J4B9LD++OgBYxZusuA7iemIIiz5yzEcFg04VZFzdFjuwPdlURmYPZw+fgVrFzj4CA64jSTG4Ig==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
+         "integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
          "cpu": [
             "x64"
          ],
@@ -1455,9 +1541,9 @@
          ]
       },
       "node_modules/@rollup/rollup-linux-x64-musl": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.25.0.tgz",
-         "integrity": "sha512-zx71aY2oQxGxAT1JShfhNG79PnjYhMC6voAjzpu/xmMjDnKNf6Nl/xv7YaB/9SIa9jDYf8RBPWEnjcdlhlv1rQ==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
+         "integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
          "cpu": [
             "x64"
          ],
@@ -1468,10 +1554,24 @@
             "linux"
          ]
       },
+      "node_modules/@rollup/rollup-openharmony-arm64": {
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
+         "integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "openharmony"
+         ]
+      },
       "node_modules/@rollup/rollup-win32-arm64-msvc": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.25.0.tgz",
-         "integrity": "sha512-JT8tcjNocMs4CylWY/CxVLnv8e1lE7ff1fi6kbGocWwxDq9pj30IJ28Peb+Y8yiPNSF28oad42ApJB8oUkwGww==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
+         "integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
          "cpu": [
             "arm64"
          ],
@@ -1483,9 +1583,9 @@
          ]
       },
       "node_modules/@rollup/rollup-win32-ia32-msvc": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.25.0.tgz",
-         "integrity": "sha512-dRLjLsO3dNOfSN6tjyVlG+Msm4IiZnGkuZ7G5NmpzwF9oOc582FZG05+UdfTbz5Jd4buK/wMb6UeHFhG18+OEg==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
+         "integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
          "cpu": [
             "ia32"
          ],
@@ -1497,9 +1597,9 @@
          ]
       },
       "node_modules/@rollup/rollup-win32-x64-msvc": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.25.0.tgz",
-         "integrity": "sha512-/RqrIFtLB926frMhZD0a5oDa4eFIbyNEwLLloMTEjmqfwZWXywwVVOVmwTsuyhC9HKkVEZcOOi+KV4U9wmOdlg==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
+         "integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
          "cpu": [
             "x64"
          ],
@@ -2399,9 +2499,9 @@
          }
       },
       "node_modules/@types/estree": {
-         "version": "1.0.6",
-         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-         "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+         "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
          "dev": true,
          "license": "MIT"
       },
@@ -2421,12 +2521,12 @@
          "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "22.10.7",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
-         "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
+         "version": "24.3.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+         "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
          "license": "MIT",
          "dependencies": {
-            "undici-types": "~6.20.0"
+            "undici-types": "~7.10.0"
          }
       },
       "node_modules/@types/protocol-buffers-schema": {
@@ -2473,16 +2573,19 @@
          "license": "MIT"
       },
       "node_modules/@vitejs/plugin-vue": {
-         "version": "5.2.4",
-         "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
-         "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+         "version": "6.0.1",
+         "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.1.tgz",
+         "integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
          "dev": true,
          "license": "MIT",
+         "dependencies": {
+            "@rolldown/pluginutils": "1.0.0-beta.29"
+         },
          "engines": {
-            "node": "^18.0.0 || >=20.0.0"
+            "node": "^20.19.0 || >=22.12.0"
          },
          "peerDependencies": {
-            "vite": "^5.0.0 || ^6.0.0",
+            "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
             "vue": "^3.2.25"
          }
       },
@@ -3349,9 +3452,9 @@
          }
       },
       "node_modules/esbuild": {
-         "version": "0.21.5",
-         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-         "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+         "version": "0.25.9",
+         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+         "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
          "dev": true,
          "hasInstallScript": true,
          "license": "MIT",
@@ -3359,32 +3462,35 @@
             "esbuild": "bin/esbuild"
          },
          "engines": {
-            "node": ">=12"
+            "node": ">=18"
          },
          "optionalDependencies": {
-            "@esbuild/aix-ppc64": "0.21.5",
-            "@esbuild/android-arm": "0.21.5",
-            "@esbuild/android-arm64": "0.21.5",
-            "@esbuild/android-x64": "0.21.5",
-            "@esbuild/darwin-arm64": "0.21.5",
-            "@esbuild/darwin-x64": "0.21.5",
-            "@esbuild/freebsd-arm64": "0.21.5",
-            "@esbuild/freebsd-x64": "0.21.5",
-            "@esbuild/linux-arm": "0.21.5",
-            "@esbuild/linux-arm64": "0.21.5",
-            "@esbuild/linux-ia32": "0.21.5",
-            "@esbuild/linux-loong64": "0.21.5",
-            "@esbuild/linux-mips64el": "0.21.5",
-            "@esbuild/linux-ppc64": "0.21.5",
-            "@esbuild/linux-riscv64": "0.21.5",
-            "@esbuild/linux-s390x": "0.21.5",
-            "@esbuild/linux-x64": "0.21.5",
-            "@esbuild/netbsd-x64": "0.21.5",
-            "@esbuild/openbsd-x64": "0.21.5",
-            "@esbuild/sunos-x64": "0.21.5",
-            "@esbuild/win32-arm64": "0.21.5",
-            "@esbuild/win32-ia32": "0.21.5",
-            "@esbuild/win32-x64": "0.21.5"
+            "@esbuild/aix-ppc64": "0.25.9",
+            "@esbuild/android-arm": "0.25.9",
+            "@esbuild/android-arm64": "0.25.9",
+            "@esbuild/android-x64": "0.25.9",
+            "@esbuild/darwin-arm64": "0.25.9",
+            "@esbuild/darwin-x64": "0.25.9",
+            "@esbuild/freebsd-arm64": "0.25.9",
+            "@esbuild/freebsd-x64": "0.25.9",
+            "@esbuild/linux-arm": "0.25.9",
+            "@esbuild/linux-arm64": "0.25.9",
+            "@esbuild/linux-ia32": "0.25.9",
+            "@esbuild/linux-loong64": "0.25.9",
+            "@esbuild/linux-mips64el": "0.25.9",
+            "@esbuild/linux-ppc64": "0.25.9",
+            "@esbuild/linux-riscv64": "0.25.9",
+            "@esbuild/linux-s390x": "0.25.9",
+            "@esbuild/linux-x64": "0.25.9",
+            "@esbuild/netbsd-arm64": "0.25.9",
+            "@esbuild/netbsd-x64": "0.25.9",
+            "@esbuild/openbsd-arm64": "0.25.9",
+            "@esbuild/openbsd-x64": "0.25.9",
+            "@esbuild/openharmony-arm64": "0.25.9",
+            "@esbuild/sunos-x64": "0.25.9",
+            "@esbuild/win32-arm64": "0.25.9",
+            "@esbuild/win32-ia32": "0.25.9",
+            "@esbuild/win32-x64": "0.25.9"
          }
       },
       "node_modules/estree-walker": {
@@ -5456,13 +5562,13 @@
          }
       },
       "node_modules/rollup": {
-         "version": "4.25.0",
-         "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.25.0.tgz",
-         "integrity": "sha512-uVbClXmR6wvx5R1M3Od4utyLUxrmOcEm3pAtMphn73Apq19PDtHpgZoEvqH2YnnaNUuvKmg2DgRd2Sqv+odyqg==",
+         "version": "4.50.0",
+         "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
+         "integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@types/estree": "1.0.6"
+            "@types/estree": "1.0.8"
          },
          "bin": {
             "rollup": "dist/bin/rollup"
@@ -5472,24 +5578,27 @@
             "npm": ">=8.0.0"
          },
          "optionalDependencies": {
-            "@rollup/rollup-android-arm-eabi": "4.25.0",
-            "@rollup/rollup-android-arm64": "4.25.0",
-            "@rollup/rollup-darwin-arm64": "4.25.0",
-            "@rollup/rollup-darwin-x64": "4.25.0",
-            "@rollup/rollup-freebsd-arm64": "4.25.0",
-            "@rollup/rollup-freebsd-x64": "4.25.0",
-            "@rollup/rollup-linux-arm-gnueabihf": "4.25.0",
-            "@rollup/rollup-linux-arm-musleabihf": "4.25.0",
-            "@rollup/rollup-linux-arm64-gnu": "4.25.0",
-            "@rollup/rollup-linux-arm64-musl": "4.25.0",
-            "@rollup/rollup-linux-powerpc64le-gnu": "4.25.0",
-            "@rollup/rollup-linux-riscv64-gnu": "4.25.0",
-            "@rollup/rollup-linux-s390x-gnu": "4.25.0",
-            "@rollup/rollup-linux-x64-gnu": "4.25.0",
-            "@rollup/rollup-linux-x64-musl": "4.25.0",
-            "@rollup/rollup-win32-arm64-msvc": "4.25.0",
-            "@rollup/rollup-win32-ia32-msvc": "4.25.0",
-            "@rollup/rollup-win32-x64-msvc": "4.25.0",
+            "@rollup/rollup-android-arm-eabi": "4.50.0",
+            "@rollup/rollup-android-arm64": "4.50.0",
+            "@rollup/rollup-darwin-arm64": "4.50.0",
+            "@rollup/rollup-darwin-x64": "4.50.0",
+            "@rollup/rollup-freebsd-arm64": "4.50.0",
+            "@rollup/rollup-freebsd-x64": "4.50.0",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.50.0",
+            "@rollup/rollup-linux-arm-musleabihf": "4.50.0",
+            "@rollup/rollup-linux-arm64-gnu": "4.50.0",
+            "@rollup/rollup-linux-arm64-musl": "4.50.0",
+            "@rollup/rollup-linux-loongarch64-gnu": "4.50.0",
+            "@rollup/rollup-linux-ppc64-gnu": "4.50.0",
+            "@rollup/rollup-linux-riscv64-gnu": "4.50.0",
+            "@rollup/rollup-linux-riscv64-musl": "4.50.0",
+            "@rollup/rollup-linux-s390x-gnu": "4.50.0",
+            "@rollup/rollup-linux-x64-gnu": "4.50.0",
+            "@rollup/rollup-linux-x64-musl": "4.50.0",
+            "@rollup/rollup-openharmony-arm64": "4.50.0",
+            "@rollup/rollup-win32-arm64-msvc": "4.50.0",
+            "@rollup/rollup-win32-ia32-msvc": "4.50.0",
+            "@rollup/rollup-win32-x64-msvc": "4.50.0",
             "fsevents": "~2.3.2"
          }
       },
@@ -6008,6 +6117,54 @@
          "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
          "license": "MIT"
       },
+      "node_modules/tinyglobby": {
+         "version": "0.2.14",
+         "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+         "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+         "dev": true,
+         "license": "MIT",
+         "dependencies": {
+            "fdir": "^6.4.4",
+            "picomatch": "^4.0.2"
+         },
+         "engines": {
+            "node": ">=12.0.0"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/SuperchupuDev"
+         }
+      },
+      "node_modules/tinyglobby/node_modules/fdir": {
+         "version": "6.5.0",
+         "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+         "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12.0.0"
+         },
+         "peerDependencies": {
+            "picomatch": "^3 || ^4"
+         },
+         "peerDependenciesMeta": {
+            "picomatch": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/tinyglobby/node_modules/picomatch": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+         "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/jonschlinkert"
+         }
+      },
       "node_modules/tldts": {
          "version": "6.1.72",
          "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.72.tgz",
@@ -6256,9 +6413,9 @@
          }
       },
       "node_modules/undici-types": {
-         "version": "6.20.0",
-         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-         "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+         "version": "7.10.0",
+         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+         "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
          "license": "MIT"
       },
       "node_modules/unraw": {
@@ -6314,21 +6471,24 @@
          }
       },
       "node_modules/vite": {
-         "version": "5.4.19",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-         "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+         "version": "7.1.4",
+         "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
+         "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "esbuild": "^0.21.3",
-            "postcss": "^8.4.43",
-            "rollup": "^4.20.0"
+            "esbuild": "^0.25.0",
+            "fdir": "^6.5.0",
+            "picomatch": "^4.0.3",
+            "postcss": "^8.5.6",
+            "rollup": "^4.43.0",
+            "tinyglobby": "^0.2.14"
          },
          "bin": {
             "vite": "bin/vite.js"
          },
          "engines": {
-            "node": "^18.0.0 || >=20.0.0"
+            "node": "^20.19.0 || >=22.12.0"
          },
          "funding": {
             "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -6337,17 +6497,23 @@
             "fsevents": "~2.3.3"
          },
          "peerDependencies": {
-            "@types/node": "^18.0.0 || >=20.0.0",
-            "less": "*",
+            "@types/node": "^20.19.0 || >=22.12.0",
+            "jiti": ">=1.21.0",
+            "less": "^4.0.0",
             "lightningcss": "^1.21.0",
-            "sass": "*",
-            "sass-embedded": "*",
-            "stylus": "*",
-            "sugarss": "*",
-            "terser": "^5.4.0"
+            "sass": "^1.70.0",
+            "sass-embedded": "^1.70.0",
+            "stylus": ">=0.54.8",
+            "sugarss": "^5.0.0",
+            "terser": "^5.16.0",
+            "tsx": "^4.8.1",
+            "yaml": "^2.4.2"
          },
          "peerDependenciesMeta": {
             "@types/node": {
+               "optional": true
+            },
+            "jiti": {
                "optional": true
             },
             "less": {
@@ -6370,7 +6536,44 @@
             },
             "terser": {
                "optional": true
+            },
+            "tsx": {
+               "optional": true
+            },
+            "yaml": {
+               "optional": true
             }
+         }
+      },
+      "node_modules/vite/node_modules/fdir": {
+         "version": "6.5.0",
+         "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+         "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12.0.0"
+         },
+         "peerDependencies": {
+            "picomatch": "^3 || ^4"
+         },
+         "peerDependenciesMeta": {
+            "picomatch": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/vite/node_modules/picomatch": {
+         "version": "4.0.3",
+         "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+         "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+         "dev": true,
+         "license": "MIT",
+         "engines": {
+            "node": ">=12"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/jonschlinkert"
          }
       },
       "node_modules/vue": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
             "@playwright/test": "^1.55.0",
             "@rollup/plugin-inject": "^5.0.5",
             "@vitejs/plugin-vue": "^5.2.4",
-            "sass": "1.79.5",
+            "sass": "1.91.0",
             "vite": "^5.4.19"
          }
       },
@@ -816,6 +816,7 @@
          "dev": true,
          "hasInstallScript": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "detect-libc": "^1.0.3",
             "is-glob": "^4.0.3",
@@ -1124,6 +1125,7 @@
          "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
          "dev": true,
          "license": "Apache-2.0",
+         "optional": true,
          "bin": {
             "detect-libc": "bin/detect-libc.js"
          },
@@ -2818,6 +2820,7 @@
          "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "fill-range": "^7.1.1"
          },
@@ -3493,6 +3496,7 @@
          "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "to-regex-range": "^5.0.1"
          },
@@ -3903,7 +3907,8 @@
       "node_modules/immutable": {
          "version": "4.3.0",
          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-         "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
+         "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+         "peer": true
       },
       "node_modules/inherits": {
          "version": "2.0.4",
@@ -4083,6 +4088,7 @@
          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "engines": {
             "node": ">=0.10.0"
          }
@@ -4126,6 +4132,7 @@
          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "is-extglob": "^2.1.1"
          },
@@ -4161,6 +4168,7 @@
          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "engines": {
             "node": ">=0.12.0"
          }
@@ -4564,6 +4572,7 @@
          "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "braces": "^3.0.3",
             "picomatch": "^2.3.1"
@@ -4693,7 +4702,8 @@
          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
          "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
          "dev": true,
-         "license": "MIT"
+         "license": "MIT",
+         "optional": true
       },
       "node_modules/node-domexception": {
          "version": "1.0.0",
@@ -5572,15 +5582,14 @@
          "license": "MIT"
       },
       "node_modules/sass": {
-         "version": "1.79.5",
-         "resolved": "https://registry.npmjs.org/sass/-/sass-1.79.5.tgz",
-         "integrity": "sha512-W1h5kp6bdhqFh2tk3DsI771MoEJjvrSY/2ihJRJS4pjIyfJCw0nTsxqhnrUzaLMOJjFchj8rOvraI/YUVjtx5g==",
+         "version": "1.91.0",
+         "resolved": "https://registry.npmjs.org/sass/-/sass-1.91.0.tgz",
+         "integrity": "sha512-aFOZHGf+ur+bp1bCHZ+u8otKGh77ZtmFyXDo4tlYvT7PWql41Kwd8wdkPqhhT+h2879IVblcHFglIMofsFd1EA==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@parcel/watcher": "^2.4.1",
             "chokidar": "^4.0.0",
-            "immutable": "^4.0.0",
+            "immutable": "^5.0.2",
             "source-map-js": ">=0.6.2 <2.0.0"
          },
          "bin": {
@@ -5588,7 +5597,17 @@
          },
          "engines": {
             "node": ">=14.0.0"
+         },
+         "optionalDependencies": {
+            "@parcel/watcher": "^2.4.1"
          }
+      },
+      "node_modules/sass/node_modules/immutable": {
+         "version": "5.1.3",
+         "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+         "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+         "dev": true,
+         "license": "MIT"
       },
       "node_modules/saxes": {
          "version": "6.0.0",
@@ -6026,6 +6045,7 @@
          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
          "dev": true,
          "license": "MIT",
+         "optional": true,
          "dependencies": {
             "is-number": "^7.0.0"
          },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,6 @@
          "license": "MIT",
          "dependencies": {
             "@asyncapi/react-component": "^2.6.3",
-            "@fortawesome/fontawesome-free": "^5.15.4",
             "@fortawesome/fontawesome-svg-core": "^1.2.36",
             "@fortawesome/free-solid-svg-icons": "^5.15.4",
             "@fortawesome/vue-fontawesome": "^3.0.3",
@@ -715,15 +714,6 @@
          "version": "0.2.36",
          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
          "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
-         "hasInstallScript": true,
-         "engines": {
-            "node": ">=6"
-         }
-      },
-      "node_modules/@fortawesome/fontawesome-free": {
-         "version": "5.15.4",
-         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
-         "integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==",
          "hasInstallScript": true,
          "engines": {
             "node": ">=6"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,9 @@
          "license": "MIT",
          "dependencies": {
             "@asyncapi/react-component": "^2.6.4",
-            "@fortawesome/fontawesome-svg-core": "^1.2.36",
-            "@fortawesome/free-solid-svg-icons": "^5.15.4",
-            "@fortawesome/vue-fontawesome": "^3.0.3",
+            "@fortawesome/fontawesome-svg-core": "^7.0.0",
+            "@fortawesome/free-solid-svg-icons": "^7.0.0",
+            "@fortawesome/vue-fontawesome": "^3.1.1",
             "bootstrap-material-design": "^4.1.3",
             "eventsource": "^4.0.0",
             "http-link-header": "^1.1.3",
@@ -711,44 +711,45 @@
          }
       },
       "node_modules/@fortawesome/fontawesome-common-types": {
-         "version": "0.2.36",
-         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-         "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
-         "hasInstallScript": true,
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
+         "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+         "license": "MIT",
          "engines": {
             "node": ">=6"
          }
       },
       "node_modules/@fortawesome/fontawesome-svg-core": {
-         "version": "1.2.36",
-         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
-         "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
-         "hasInstallScript": true,
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
+         "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+         "license": "MIT",
          "dependencies": {
-            "@fortawesome/fontawesome-common-types": "^0.2.36"
+            "@fortawesome/fontawesome-common-types": "7.0.0"
          },
          "engines": {
             "node": ">=6"
          }
       },
       "node_modules/@fortawesome/free-solid-svg-icons": {
-         "version": "5.15.4",
-         "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
-         "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
-         "hasInstallScript": true,
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
+         "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+         "license": "(CC-BY-4.0 AND MIT)",
          "dependencies": {
-            "@fortawesome/fontawesome-common-types": "^0.2.36"
+            "@fortawesome/fontawesome-common-types": "7.0.0"
          },
          "engines": {
             "node": ">=6"
          }
       },
       "node_modules/@fortawesome/vue-fontawesome": {
-         "version": "3.0.3",
-         "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz",
-         "integrity": "sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==",
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.1.1.tgz",
+         "integrity": "sha512-U5azn4mcUVpjHe4JO0Wbe7Ih8e3VbN83EH7OTBtA5/QGw9qcPGffqcmwsLyZYgEkpVkYbq/6dX1Iyl5KUGMp6Q==",
+         "license": "MIT",
          "peerDependencies": {
-            "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+            "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
             "vue": ">= 3.0.0 < 4"
          }
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,8 +29,8 @@
    "devDependencies": {
       "@playwright/test": "^1.55.0",
       "@rollup/plugin-inject": "^5.0.5",
-      "@vitejs/plugin-vue": "^5.2.4",
+      "@vitejs/plugin-vue": "^6.0.1",
       "sass": "1.91.0",
-      "vite": "^5.4.19"
+      "vite": "^7.1.4"
    }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
       "@fortawesome/free-solid-svg-icons": "^5.15.4",
       "@fortawesome/vue-fontawesome": "^3.0.3",
       "bootstrap-material-design": "^4.1.3",
-      "core-js": "^3.45.1",
       "eventsource": "^4.0.0",
       "http-link-header": "^1.1.3",
       "jquery": "^3.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,9 +11,9 @@
    },
    "dependencies": {
       "@asyncapi/react-component": "^2.6.4",
-      "@fortawesome/fontawesome-svg-core": "^1.2.36",
-      "@fortawesome/free-solid-svg-icons": "^5.15.4",
-      "@fortawesome/vue-fontawesome": "^3.0.3",
+      "@fortawesome/fontawesome-svg-core": "^7.0.0",
+      "@fortawesome/free-solid-svg-icons": "^7.0.0",
+      "@fortawesome/vue-fontawesome": "^3.1.1",
       "bootstrap-material-design": "^4.1.3",
       "eventsource": "^4.0.0",
       "http-link-header": "^1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
       "jquery": "^3.7.1",
       "moment": "^2.30.1",
       "popper.js": "^1.16.1",
-      "swagger-ui": "^5.27.1",
+      "swagger-ui": "^5.28.1",
       "vue": "^3.5.21",
       "vue-router": "^4.5.1",
       "vue-virtual-scroller": "^2.0.0-beta.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
       "moment": "^2.30.1",
       "popper.js": "^1.16.1",
       "swagger-ui": "^5.27.1",
-      "vue": "^3.5.20",
+      "vue": "^3.5.21",
       "vue-router": "^4.5.1",
       "vue-virtual-scroller": "^2.0.0-beta.8",
       "vuex": "^4.1.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
       "@playwright/test": "^1.55.0",
       "@rollup/plugin-inject": "^5.0.5",
       "@vitejs/plugin-vue": "^5.2.4",
-      "sass": "1.79.5",
+      "sass": "1.91.0",
       "vite": "^5.4.19"
    }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
       "test:e2e:ui": "playwright test --ui"
    },
    "dependencies": {
-      "@asyncapi/react-component": "^2.6.3",
+      "@asyncapi/react-component": "^2.6.4",
       "@fortawesome/fontawesome-svg-core": "^1.2.36",
       "@fortawesome/free-solid-svg-icons": "^5.15.4",
       "@fortawesome/vue-fontawesome": "^3.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
    },
    "dependencies": {
       "@asyncapi/react-component": "^2.6.3",
-      "@fortawesome/fontawesome-free": "^5.15.4",
       "@fortawesome/fontawesome-svg-core": "^1.2.36",
       "@fortawesome/free-solid-svg-icons": "^5.15.4",
       "@fortawesome/vue-fontawesome": "^3.0.3",

--- a/frontend/src/scss/_application.scss
+++ b/frontend/src/scss/_application.scss
@@ -1,3 +1,5 @@
+@use "colors";
+
 /*-
  * ========================LICENSE_START=================================
  * PREvant Frontend
@@ -35,7 +37,7 @@
 body {
    padding: 7rem 0;
 
-   background-color: $app-background-color;
+   background-color: colors.$app-background-color;
 }
 
 .container {
@@ -46,7 +48,7 @@ body {
 
       margin-bottom: 1rem;
 
-      color: $dusty-gray;
+      color: colors.$dusty-gray;
    }
 }
 

--- a/frontend/src/scss/_badge.scss
+++ b/frontend/src/scss/_badge.scss
@@ -1,3 +1,5 @@
+@use "colors";
+
 /*-
  * ========================LICENSE_START=================================
  * PREvant Frontend
@@ -37,25 +39,25 @@
 }
 
 .jira--new {
-   background-color: $jira-new;
+   background-color: colors.$jira-new;
 }
 
 .jira--concept {
-   background-color: $jira-concept;
+   background-color: colors.$jira-concept;
 }
 
 .jira--ready {
-   background-color: $jira-ready;
+   background-color: colors.$jira-ready;
 }
 
 .jira--process {
-   background-color: $jira-process;
+   background-color: colors.$jira-process;
 }
 
 .jira--review {
-   background-color: $jira-review;
+   background-color: colors.$jira-review;
 }
 
 .jira--done {
-   background-color: $jira-done;
+   background-color: colors.$jira-done;
 }

--- a/frontend/src/scss/_card.scss
+++ b/frontend/src/scss/_card.scss
@@ -1,3 +1,5 @@
+@use "colors";
+
 /*-
  * ========================LICENSE_START=================================
  * PREvant Frontend
@@ -47,19 +49,19 @@
    }
 
    .badge-info {
-      background-color: $pale-sky;
+      background-color: colors.$pale-sky;
    }
 
    .badge-secondary {
-      color: $oxford-blue;
-      background-color: $silver;
+      color: colors.$oxford-blue;
+      background-color: colors.$silver;
    }
 
    .card-header {
       padding: 1rem;
 
       color: white;
-      background-color: $pale-sky;
+      background-color: colors.$pale-sky;
 
       a {
          color: currentColor;
@@ -77,6 +79,6 @@
    .card-body {
       padding: .5rem 1rem;
 
-      color: $pale-sky;
+      color: colors.$pale-sky;
    }
 }

--- a/frontend/src/scss/_review-app-card.scss
+++ b/frontend/src/scss/_review-app-card.scss
@@ -1,3 +1,5 @@
+@use "colors";
+
 /*-
  * ========================LICENSE_START=================================
  * PREvant Frontend
@@ -30,7 +32,7 @@
    padding: .5em 0;
 
    & + & {
-      border-top: 1px solid $silver;
+      border-top: 1px solid colors.$silver;
    }
 }
 
@@ -51,11 +53,11 @@
 .ra-build-infos {
    margin-top: .25rem;
 
-   color: $dusty-gray;
+   color: colors.$dusty-gray;
 
    a:hover,
    a:focus {
-      color: $aqua-deep;
+      color: colors.$aqua-deep;
    }
 
    a + a {

--- a/frontend/src/scss/theme.scss
+++ b/frontend/src/scss/theme.scss
@@ -24,10 +24,10 @@
  * =========================LICENSE_END==================================
  */
 
-@import 'colors';
-@import 'basics';
-@import 'application';
-@import 'menu';
-@import 'badge';
-@import 'card';
-@import 'review-app-card';
+@use 'colors';
+@use 'basics';
+@use 'application';
+@use 'menu';
+@use 'badge';
+@use 'card';
+@use 'review-app-card';

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -110,7 +110,13 @@ export default defineConfig({
       inject({
          $: 'jquery',
          jQuery: 'jquery',
-         Popper: ['popper.js', 'default']
+         Popper: ['popper.js', 'default'],
+
+         // Exclude CSS files, especially those imported by Swagger UI (swagger-ui.css),
+         // because rollup-plugin-inject tries to parse all files as JavaScript. 
+         // Parsing CSS as JS causes warnings like:
+         //   "rollup-plugin-inject: failed to parse ...swagger-ui.css?... Consider restricting the plugin"
+         exclude: ['**/*.css']
       })
    ],
    server: {


### PR DESCRIPTION
## Summary

Optimized dependencies.

## Details

- Removed unused dependencies
- Updated all remaining dependencies
- ~Did not update swagger-ui because of https://github.com/swagger-api/swagger-ui/issues/10553~
- Upgraded to node v22 LTS
- Did some changes to properly handle deprecation warnings

--- 

The next step would be to drop jquery, popper and bootstrap and replace it with https://mdbootstrap.com/ 
