### PR TITLE
Run ID Token Claims to Owner Hook Early

### DIFF
--- a/api/src/apps/queue.rs
+++ b/api/src/apps/queue.rs
@@ -1,8 +1,5 @@
 use super::{AppsService, AppsServiceError};
-use crate::{
-    auth::User,
-    models::{App, AppName, AppStatusChangeId, ServiceConfig},
-};
+use crate::models::{App, AppName, AppStatusChangeId, Owner, ServiceConfig};
 use anyhow::Result;
 use chrono::{DateTime, TimeDelta, Utc};
 use rocket::{
@@ -88,7 +85,7 @@ impl AppTaskQueueProducer {
         app_name: AppName,
         replicate_from: Option<AppName>,
         service_configs: Vec<ServiceConfig>,
-        user: User,
+        owner: Option<Owner>,
         user_defined_parameters: Option<serde_json::Value>,
     ) -> Result<AppStatusChangeId> {
         let status_id = AppStatusChangeId::new();
@@ -98,7 +95,7 @@ impl AppTaskQueueProducer {
                 status_id,
                 replicate_from,
                 service_configs,
-                user,
+                owners: owner.into_iter().collect(),
                 user_defined_parameters,
             })
             .await?;
@@ -189,7 +186,7 @@ impl AppTaskQueueConsumer {
                         app_name,
                         replicate_from,
                         service_configs,
-                        user,
+                        owners,
                         user_defined_parameters,
                         ..
                     } => {
@@ -200,7 +197,7 @@ impl AppTaskQueueConsumer {
                             &app_name,
                             replicate_from,
                             &service_configs,
-                            user,
+                            owners,
                             user_defined_parameters,
                         )
                         .await
@@ -229,7 +226,7 @@ enum AppTask {
         status_id: AppStatusChangeId,
         replicate_from: Option<AppName>,
         service_configs: Vec<ServiceConfig>,
-        user: User,
+        owners: Vec<Owner>,
         user_defined_parameters: Option<serde_json::Value>,
     },
     Delete {

--- a/api/src/apps/routes/get_apps.rs
+++ b/api/src/apps/routes/get_apps.rs
@@ -375,7 +375,7 @@ mod tests {
                     &AppName::master(),
                     None,
                     &vec![sc!("service-a")],
-                    crate::auth::User::Anonymous,
+                    vec![],
                     None,
                 )
                 .await?;

--- a/api/src/apps/routes/logs.rs
+++ b/api/src/apps/routes/logs.rs
@@ -217,12 +217,13 @@ mod test {
                 &AppName::master(),
                 None,
                 &vec![sc!("service-a")],
-                crate::auth::User::Anonymous,
+                vec![],
                 None,
             )
             .await?;
 
         let rocket = rocket::build()
+            .manage(Config::default())
             .manage(host_meta_cache)
             .manage(apps)
             .mount("/api/apps", routes![logs, stream_logs]);

--- a/api/src/deployment/hooks.rs
+++ b/api/src/deployment/hooks.rs
@@ -1,30 +1,5 @@
-use crate::auth::User;
-/*-
- * ========================LICENSE_START=================================
- * PREvant REST API
- * %%
- * Copyright (C) 2018 - 2021 aixigo AG
- * %%
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * =========================LICENSE_END==================================
- */
 use super::deployment_unit::DeployableService;
+use crate::auth::User;
 use crate::config::Config;
 use crate::models::{AppName, ContainerType, Environment, EnvironmentVariable, Image, Owner};
 use boa_engine::property::Attribute;


### PR DESCRIPTION
In preparation of a persistent worker-producer queue (see #262) this commit moves the application of the “ID Token Claims to Owner Mapping” hook earlier in the process. This will unlock #262 to avoid (de)serializations of the user struct.