### PR TITLE
Cache the Ticketing Information

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
  "home",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-named-pipe",
  "hyper-rustls",
  "hyper-util",
@@ -612,18 +612,18 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytesize"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c434ae3cf0089ca203e9019ebe529c47ff45cefe8af7c85ecb734ef541822f"
+checksum = "c99fa31e08a43eaa5913ef68d7e01c37a2bdce6ed648168239ad33b7d30a9cd8"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1958,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1989,7 +1989,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 1.3.1",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -2006,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "log",
  "rustls",
@@ -2039,7 +2039,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2054,7 +2054,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2075,7 +2075,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2096,7 +2096,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2468,22 +2468,22 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2608,7 +2608,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-http-proxy",
  "hyper-rustls",
  "hyper-timeout",
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",
@@ -3154,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3186,9 +3186,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -3569,7 +3569,7 @@ dependencies = [
  "http 1.3.1",
  "http-api-problem",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "jira_query",
  "jsonschema",
@@ -3760,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -3930,7 +3930,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4239,9 +4239,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1317c3bf3e7df961da95b0a56a172a02abead31276215a0497241a7624b487ce"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4495,7 +4495,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.12.0",
  "schemars 0.9.0",
- "schemars 1.0.5",
+ "schemars 1.1.0",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4943,9 +4943,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5405,7 +5405,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -5672,15 +5672,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",

--- a/api/src/config/mod.rs
+++ b/api/src/config/mod.rs
@@ -195,11 +195,11 @@ pub struct JiraConfig {
 pub enum JiraAuth {
     Basic {
         user: String,
-        password: SecUtf8,
+        password: MaybeEnvInterpolated<SecUtf8>,
     },
     #[serde(rename_all = "camelCase")]
     ApiKey {
-        api_key: SecUtf8,
+        api_key: MaybeEnvInterpolated<SecUtf8>,
     },
 }
 
@@ -1056,7 +1056,7 @@ mod tests {
             jira_config.auth(),
             &JiraAuth::Basic {
                 user: String::from("user"),
-                password: SecUtf8::from_str("pass").unwrap()
+                password: MaybeEnvInterpolated(SecUtf8::from_str("pass").unwrap())
             }
         );
     }
@@ -1076,7 +1076,7 @@ mod tests {
         assert_eq!(
             jira_config.auth(),
             &JiraAuth::ApiKey {
-                api_key: SecUtf8::from_str("key").unwrap()
+                api_key: MaybeEnvInterpolated(SecUtf8::from_str("key").unwrap())
             }
         );
     }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -34,6 +34,7 @@ use crate::apps::Apps;
 use crate::config::{Config, Runtime};
 use crate::infrastructure::{Docker, Infrastructure, Kubernetes};
 use crate::models::request_info::RequestInfo;
+use crate::tickets::TicketsCaching;
 use apps::AppProcessingQueue;
 use auth::Auth;
 use auth::Issuers;
@@ -231,11 +232,12 @@ async fn main() -> Result<(), StartUpError> {
         )
         .mount("/openapi.yaml", routes![openapi])
         .mount("/api/apps", crate::apps::apps_routes())
-        .mount("/api", routes![tickets::tickets])
+        .mount("/api", crate::tickets::ticket_routes())
         .mount("/api", routes![webhooks::webhooks])
         .mount("/auth", crate::auth::auth_routes())
         .attach(Auth::fairing())
         .attach(AppProcessingQueue::fairing())
+        .attach(TicketsCaching::fairing())
         .launch()
         .await?;
 

--- a/api/src/models/ticket_info.rs
+++ b/api/src/models/ticket_info.rs
@@ -28,10 +28,11 @@ use serde::ser::{Serialize, Serializer};
 use std::convert::From;
 use url::Url;
 
+#[derive(Eq, PartialEq, Hash)]
 pub struct TicketInfo {
-    link: Url,
-    summary: String,
-    status: String,
+    pub link: Url,
+    pub summary: String,
+    pub status: String,
 }
 
 impl From<Issue> for TicketInfo {

--- a/api/src/tickets.rs
+++ b/api/src/tickets.rs
@@ -24,61 +24,204 @@
  * =========================LICENSE_END==================================
  */
 
-use crate::apps::Apps;
-use crate::config::Config;
+use crate::config::{Config, JiraConfig};
 use crate::http_result::{HttpApiError, HttpResult};
 use crate::models::ticket_info::TicketInfo;
+use crate::models::{App, AppName};
+use evmap::{ReadHandleFactory, WriteHandle};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use http_api_problem::{HttpApiProblem, StatusCode};
 use jira_query::{JiraInstance, JiraQueryError};
 use log::debug;
+use rocket::fairing::{Fairing, Info};
 use rocket::serde::json::Json;
-use rocket::State;
+use rocket::{Build, Orbit, Rocket, State};
 use std::collections::HashMap;
 use std::convert::From;
-use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::watch::Receiver;
+use tokio_stream::wrappers::WatchStream;
 
-/// Analyzes running containers and returns a map of `review-app-name` with the
-/// corresponding `TicketInfo`.
+pub fn ticket_routes() -> Vec<rocket::Route> {
+    rocket::routes![tickets_route]
+}
+
 #[rocket::get("/apps/tickets", format = "application/json")]
-pub async fn tickets(
-    config_state: &State<Config>,
-    apps_service: &State<Arc<Apps>>,
-) -> HttpResult<Json<HashMap<String, TicketInfo>>> {
-    let mut tickets: HashMap<String, TicketInfo> = HashMap::new();
+fn tickets_route(cache: &State<TicketsCache>) -> HttpResult<Json<SerializableTickets>> {
+    match cache.serializable_tickets() {
+        Some(tickets) => Ok(Json(tickets)),
+        None => Err(ListTicketsError::MissingIssueTrackingConfiguration.into()),
+    }
+}
 
-    match config_state.jira_config() {
-        None => {
-            return Err(ListTicketsError::MissingIssueTrackingConfiguration.into());
+#[derive(Debug, thiserror::Error)]
+pub enum ListTicketsError {
+    #[error("No issue tracking configuration")]
+    MissingIssueTrackingConfiguration,
+}
+
+impl From<ListTicketsError> for HttpApiError {
+    fn from(error: ListTicketsError) -> Self {
+        let status = match error {
+            ListTicketsError::MissingIssueTrackingConfiguration => StatusCode::NO_CONTENT,
+        };
+
+        HttpApiProblem::with_title_and_type(status)
+            .detail(format!("{error}"))
+            .into()
+    }
+}
+
+pub struct TicketsCaching {
+    reader_factory: ReadHandleFactory<AppName, Box<TicketInfo>>,
+    writer: Mutex<Option<WriteHandle<AppName, Box<TicketInfo>>>>,
+}
+
+impl TicketsCaching {
+    pub fn fairing() -> Self {
+        let (reader, writer) = evmap::new();
+        Self {
+            reader_factory: reader.factory(),
+            writer: Mutex::new(Some(writer)),
         }
-        Some(jira_config) => {
-            let app_names = apps_service.fetch_app_names().await?;
-            if app_names.is_empty() {
-                return Ok(Json(tickets));
+    }
+}
+
+#[rocket::async_trait]
+impl Fairing for TicketsCaching {
+    fn info(&self) -> Info {
+        Info {
+            name: "ticket-cache",
+            kind: rocket::fairing::Kind::Ignite | rocket::fairing::Kind::Liftoff,
+        }
+    }
+
+    async fn on_ignite(&self, rocket: Rocket<Build>) -> rocket::fairing::Result {
+        let Some(config) = rocket.state::<Config>() else {
+            log::error!("No configuration object available");
+            return Err(rocket);
+        };
+
+        match config.jira_config() {
+            Some(_jira_config) => Ok(rocket.manage(TicketsCache {
+                reader_factory: Some(self.reader_factory.clone()),
+            })),
+            None => Ok(rocket.manage(TicketsCache {
+                reader_factory: None,
+            })),
+        }
+    }
+
+    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
+        let Some(config) = rocket.state::<Config>() else {
+            todo!()
+        };
+
+        if let Some(jira_config) = config.jira_config() {
+            let app_updates = rocket
+                .state::<Receiver<HashMap<AppName, App>>>()
+                .expect("App update should be available");
+
+            let writer = {
+                let mut writer = self.writer.lock().unwrap();
+                writer.take().unwrap()
+            };
+            let crawler = TicketsCrawler {
+                jira_config,
+                app_updates: app_updates.clone(),
+                writer,
+            };
+
+            rocket::tokio::spawn(async move { crawler.spawn_loop().await });
+        }
+    }
+}
+
+struct TicketsCache {
+    reader_factory: Option<ReadHandleFactory<AppName, Box<TicketInfo>>>,
+}
+
+struct SerializableTickets(ReadHandleFactory<AppName, Box<TicketInfo>>);
+
+impl serde::ser::Serialize for SerializableTickets {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let handle = self.0.handle();
+
+        let mut map = serializer.serialize_map(None)?;
+        if let Some(read) = handle.read() {
+            for (app_name, ticket) in read.iter() {
+                map.serialize_entry(app_name, ticket.get_one().unwrap())?;
+            }
+        }
+        map.end()
+    }
+}
+
+impl TicketsCache {
+    fn serializable_tickets(&self) -> Option<SerializableTickets> {
+        self
+            .reader_factory
+            .as_ref()
+            .map(|reader_factory| SerializableTickets(reader_factory.clone()))
+    }
+}
+
+struct TicketsCrawler {
+    jira_config: JiraConfig,
+    app_updates: Receiver<HashMap<AppName, App>>,
+    writer: WriteHandle<AppName, Box<TicketInfo>>,
+}
+
+impl TicketsCrawler {
+    async fn spawn_loop(mut self) {
+        let mut app_updates = WatchStream::from_changes(self.app_updates);
+        let mut app_names = Vec::<AppName>::new();
+        loop {
+            tokio::select! {
+                Some(changed) = app_updates.next() => {
+                    log::debug!("Got new app names");
+                    app_names = changed.into_keys().collect::<Vec<_>>();
+                }
+                _ = tokio::time::sleep(std::time::Duration::from_secs(120)) => {
+                    log::debug!("Regular tickets check.");
+                }
             }
 
-            let jira = JiraInstance::at(jira_config.host().clone())
+            if app_names.is_empty() {
+                continue;
+            }
+
+            let jira = JiraInstance::at(self.jira_config.host().clone())
                 .unwrap()
-                .authenticate(match jira_config.auth() {
+                .authenticate(match self.jira_config.auth() {
                     crate::config::JiraAuth::Basic { user, password } => jira_query::Auth::Basic {
                         user: user.clone(),
-                        password: password.unsecure().to_string(),
+                        password: password.0.unsecure().to_string(),
                     },
                     crate::config::JiraAuth::ApiKey { api_key } => {
-                        jira_query::Auth::ApiKey(api_key.unsecure().to_string())
+                        jira_query::Auth::ApiKey(api_key.0.unsecure().to_string())
                     }
                 });
 
-            let mut futures = app_names
+            self.writer.purge();
+
+            let app_names_clone = app_names.clone();
+            let mut futures = app_names_clone
                 .iter()
-                .map(|app_name| jira.issue(app_name))
+                .map(|app_name| async { (app_name.clone(), jira.issue(app_name).await) })
                 .collect::<FuturesUnordered<_>>();
 
-            while let Some(r) = futures.next().await {
-                match r {
+            while let Some((app_name, jira_result)) = futures.next().await {
+                match jira_result {
                     Ok(issue) => {
-                        tickets.insert(issue.key.clone(), TicketInfo::from(issue));
+                        debug!("Found issue {}", issue.key);
+                        self.writer
+                            .insert(app_name, Box::new(TicketInfo::from(issue)));
                     }
                     Err(JiraQueryError::MissingIssues(issues)) => {
                         debug!("Cannot query issue information for {issues:?}");
@@ -87,36 +230,108 @@ pub async fn tickets(
                         debug!("Cannot deserialize issue, assuming it cannot be decoded due to issue not being found: {err}");
                     }
                     Err(err) => {
-                        return Err(ListTicketsError::UnexpectedError {
-                            err: anyhow::Error::new(err),
-                        }
-                        .into());
+                        log::error!("Cannot fetch ticketing information: {err}");
                     }
                 }
             }
+
+            self.writer.refresh();
+            self.writer.flush();
         }
-    };
-
-    Ok(Json(tickets))
+    }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ListTicketsError {
-    #[error("No issue tracking configuration")]
-    MissingIssueTrackingConfiguration,
-    #[error("Unexpected issue tracking system error: {err}")]
-    UnexpectedError { err: anyhow::Error },
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_json_diff::assert_json_eq;
+    use rocket::{http::ContentType, local::asynchronous::Client};
+    use std::str::FromStr;
+    use url::Url;
 
-impl From<ListTicketsError> for HttpApiError {
-    fn from(error: ListTicketsError) -> Self {
-        let status = match error {
-            ListTicketsError::MissingIssueTrackingConfiguration => StatusCode::NO_CONTENT,
-            ListTicketsError::UnexpectedError { err: _ } => StatusCode::INTERNAL_SERVER_ERROR,
+    #[tokio::test]
+    async fn respond_with_filled_ticket_cache() {
+        let (reader, mut writer) = evmap::new();
+
+        writer.insert(
+            AppName::master(),
+            Box::new(TicketInfo {
+                link: Url::from_str("https://tickets.example.com").unwrap(),
+                summary: String::from("summary"),
+                status: String::from("status"),
+            }),
+        );
+        writer.refresh();
+        writer.flush();
+
+        let cache = TicketsCache {
+            reader_factory: Some(reader.factory()),
+        };
+        let rocket = rocket::build()
+            .mount("/", rocket::routes![tickets_route])
+            .manage(cache);
+
+        let client = Client::tracked(rocket).await.expect("valid rocket config");
+        let response = client
+            .get("/apps/tickets")
+            .header(ContentType::JSON)
+            .dispatch()
+            .await;
+
+        let body_str = response.into_string().await.expect("valid response body");
+        let actual: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        assert_json_eq!(
+            actual,
+            serde_json::json!({
+                "master": {
+                    "link": "https://tickets.example.com/",
+                    "summary": "summary",
+                    "status": "status",
+                }
+            })
+        )
+    }
+
+    #[tokio::test]
+    async fn respond_with_empty_ticket_cache() {
+        let (reader, _writer) = evmap::new();
+
+        let cache = TicketsCache {
+            reader_factory: Some(reader.factory()),
+        };
+        let rocket = rocket::build()
+            .mount("/", rocket::routes![tickets_route])
+            .manage(cache);
+
+        let client = Client::tracked(rocket).await.expect("valid rocket config");
+        let response = client
+            .get("/apps/tickets")
+            .header(ContentType::JSON)
+            .dispatch()
+            .await;
+
+        let body_str = response.into_string().await.expect("valid response body");
+        let actual: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+        assert_json_eq!(actual, serde_json::json!({}))
+    }
+
+    #[tokio::test]
+    async fn respond_with_no_ticket_information() {
+        let cache = TicketsCache {
+            reader_factory: None,
         };
 
-        HttpApiProblem::with_title_and_type(status)
-            .detail(format!("{error}"))
-            .into()
+        let rocket = rocket::build()
+            .mount("/", rocket::routes![tickets_route])
+            .manage(cache);
+
+        let client = Client::tracked(rocket).await.expect("valid rocket config");
+        let response = client
+            .get("/apps/tickets")
+            .header(ContentType::JSON)
+            .dispatch()
+            .await;
+
+        assert_eq!(rocket::http::Status::NoContent, response.status())
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,14 +77,14 @@ Currently, Jira is supported as the tracking system.
 ```toml
 [jira]
 host = 'https://jira.example.com'
-apiKey = ''
+apiKey = '${env:JIRA_API_KEY}'
 ```
 
 ```toml
 [jira]
 host = 'https://jira.example.com'
 user = ''
-password = ''
+password = '${env:JIRA_PASSWORD}'
 ```
 
 ## Frontend options


### PR DESCRIPTION
In order to reduce the HTTP traffic to the ticketing system, i.e. Jira, PREvant caches the responses. Before the change during a day of operating the system, we see following Prometheus metrics:

<img width="1328" height="558" alt="PREvant - 01 - Before" src="https://github.com/user-attachments/assets/447f11be-dee7-44ee-8954-da82ee3f4acf" />

After the change, we see following behavior:

<img width="1635" height="557" alt="PREvant - 02 - After" src="https://github.com/user-attachments/assets/60b25f04-142f-42d4-91e4-022783119a21" />

The network traffic is reduced by a lot and also the dashboard reacts more snappy because sometimes when too many people accessed the dashboard some requests were queue because of slow requests to Jira.


