### PR TITLE
Improve Handling of Traefik Rules and Middlewares

### DIFF
--- a/api/src/apps/mod.rs
+++ b/api/src/apps/mod.rs
@@ -34,9 +34,7 @@ use crate::config::{Config, ConfigError};
 use crate::deployment::deployment_unit::DeploymentTemplatingError;
 use crate::deployment::deployment_unit::DeploymentUnitBuilder;
 use crate::deployment::hooks::HooksError;
-use crate::infrastructure::HttpForwarder;
-use crate::infrastructure::Infrastructure;
-use crate::infrastructure::TraefikIngressRoute;
+use crate::infrastructure::{HttpForwarder, Infrastructure, TraefikIngressRoute};
 use crate::models::user_defined_parameters::UserDefinedParameters;
 use crate::models::Owner;
 use crate::models::{App, AppName, ContainerType, LogChunk, Service, ServiceConfig, ServiceStatus};
@@ -363,6 +361,9 @@ impl Apps {
                 );
                 deployment_unit_builder
                     .apply_base_traefik_ingress_route(base_traefik_ingress_route.clone())
+                    .map_err(|e| AppsError::BaseRouteNotMergeable {
+                        error: e.to_string(),
+                    })?
                     .build()
             } else {
                 deployment_unit_builder.build()
@@ -472,6 +473,8 @@ pub enum AppsError {
     AppNotFound { app_name: AppName },
     #[error("Cannot create more than {limit} apps")]
     AppLimitExceeded { limit: usize },
+    #[error("Cannot merge the base route: {error}")]
+    BaseRouteNotMergeable { error: String },
     /// Will be used when the service cannot interact correctly with the infrastructure.
     #[error("Cannot interact with infrastructure: {error}")]
     InfrastructureError { error: String },

--- a/api/src/apps/routes/mod.rs
+++ b/api/src/apps/routes/mod.rs
@@ -579,6 +579,7 @@ impl From<AppsError> for HttpApiError {
             },
             AppsError::AppNotFound { .. } => StatusCode::NOT_FOUND,
             AppsError::InfrastructureError { .. }
+            | AppsError::BaseRouteNotMergeable { .. }
             | AppsError::InvalidServerConfiguration { .. }
             | AppsError::TemplatingIssue { .. }
             | AppsError::UnapplicableHook { .. } => {

--- a/api/src/infrastructure/docker.rs
+++ b/api/src/infrastructure/docker.rs
@@ -460,14 +460,14 @@ impl DockerInfrastructure {
                     let mut applied_middle_wares = String::new();
                     for middleware in route.middlewares() {
                         for (key, value) in middleware.to_key_value_spec() {
+                            let middleware_name = &middleware.name;
                             if !applied_middle_wares.is_empty() {
-                                applied_middle_wares += ",";
+                                applied_middle_wares += ", ";
                             }
-                            applied_middle_wares += &format!("{}@docker", middleware.name);
+                            applied_middle_wares += &middleware_name;
                             labels.insert(
                                 format!(
-                                    "traefik.http.middlewares.{}.{}",
-                                    middleware.name,
+                                    "traefik.http.middlewares.{middleware_name}.{}",
                                     key.to_lowercase()
                                 ),
                                 value,
@@ -1779,7 +1779,7 @@ mod tests {
             expected: serde_json::json!({
               "Labels": {
                 "traefik.http.routers.master-db.rule": "PathPrefix(`/master/db/`)",
-                "traefik.http.routers.master-db.middlewares": "master-db-middleware@docker",
+                "traefik.http.routers.master-db.middlewares": "master-db-middleware",
                 "traefik.http.middlewares.master-db-middleware.stripprefix.prefixes": "/master/db/",
                 "traefik.docker.network": "master-net",
               }

--- a/api/src/infrastructure/kubernetes/deployment_unit.rs
+++ b/api/src/infrastructure/kubernetes/deployment_unit.rs
@@ -1442,6 +1442,7 @@ mod tests {
                     &AppName::master(),
                 ),
             )
+            .unwrap()
             .build();
 
         K8sDeploymentUnit::parse_from_log_streams(&deployment_unit, log_streams)

--- a/api/src/infrastructure/mod.rs
+++ b/api/src/infrastructure/mod.rs
@@ -31,7 +31,9 @@ pub use dummy_infrastructure::DummyInfrastructure as Dummy;
 pub use infrastructure::{HttpForwarder, Infrastructure};
 pub use kubernetes::KubernetesInfrastructure as Kubernetes;
 use serde_json::{map::Map, Value};
-pub use traefik::{TraefikIngressRoute, TraefikMiddleware, TraefikRouterRule};
+pub use traefik::{
+    TraefikIngressRoute, TraefikIngressRouteMergeError, TraefikMiddleware, TraefikRouterRule,
+};
 
 mod docker;
 #[cfg(test)]


### PR DESCRIPTION
This change provides support of handling the PathRegexp rule of Traefik v3. On top of that the merging logic is now more robust and presents errors to client if some assumption of Traefik ingress merging is violated.

Additionally, the naming of custom middlewares has been improved so that the names are unique, fixing Traefik complains.