### PR TITLE
fix(repository): replace peek_result panic with InfrastructureError

### DIFF
--- a/api/src/apps/repository.rs
+++ b/api/src/apps/repository.rs
@@ -282,9 +282,18 @@ impl AppPostgresRepository {
                 (None, Some(err), None, None) => Err(err),
                 (None, None, Some(app), None) => Ok(app.into()),
                 (None, None, None, Some(err)) => Err(err),
-                _ => unreachable!(
-                    "There should be either a result or an error stored in the database"
-                ),
+                // A row was returned (status = 'done') but neither the
+                // task nor the merged-with task carries a result. We've
+                // seen this happen in production when the executor
+                // failed to write the result back (#307). Surface it as
+                // an infrastructure error rather than panicking, so the
+                // caller can return a 500 and the task is left in a
+                // recoverable state.
+                _ => Err(AppsError::InfrastructureError {
+                    error: format!(
+                        "Task {status_id} is marked done but has neither a success nor an error result stored"
+                    ),
+                }),
             }
         })
     }


### PR DESCRIPTION
## Summary

Closes #307.

`peek_result` (`api/src/apps/repository.rs`) panics via `unreachable!()` when the database returns a row whose `status = 'done'` but whose `result_success` and `result_error` columns (and the merged-with task's columns) are all NULL. The incident in #307 shows this state does occur in production, the operator's database had ten such rows:

```sql
SELECT id, created_at FROM app_task a
WHERE result_success is null AND result_error is null AND a.status = 'done';
-- 10 rows
```

The `unreachable!()` therefore reduced PREvant to a panicking task fetcher whenever a corrupt row was peeked.

## Fix

Replace the unreachable arm with `Err(AppsError::InfrastructureError { error: ... })` so the caller can return a 500, the operator can inspect/repair the row, and the rest of the system keeps running:

```rust
_ => Err(AppsError::InfrastructureError {
    error: format!(
        "Task {status_id} is marked done but has neither a success nor an error result stored"
    ),
}),
```

The error variant is already exported and is the closest semantic match for "the task ran but its outcome wasn't persisted".

## Test plan

- [x] `cargo build -p prevant`, passes
- [ ] Maintainer verification on the live staging environment (or a manually-corrupted `app_task` row) that the API now returns 500 with the new error message instead of crashing the worker.